### PR TITLE
Remove link to Quest-specific stats tool

### DIFF
--- a/src/operators/community-resources.md
+++ b/src/operators/community-resources.md
@@ -32,5 +32,4 @@ on building your own integration, check out the [Oasis Core Developer Docs].
 
 ## Monitoring and Alerts
 
-- [Stats Tool (by Oasis Protocol Foundation)](https://github.com/oasisprotocol/oasis-core/tree/master/go/extra/stats)
 - [Panic Monitoring Tool (by Simply VC)](https://github.com/SimplyVC/panic_oasis)


### PR DESCRIPTION
This tool was used to compute availability scores for the Quest and is no longer relevant.