### PR TITLE
oasis-network: Mainnet oasis-core version to v21.3.10

### DIFF
--- a/docs/general/oasis-network/network-parameters.md
+++ b/docs/general/oasis-network/network-parameters.md
@@ -29,7 +29,7 @@ Feel free to use other seed nodes besides the one provided here.
 :::
 
 * [Oasis Core](https://github.com/oasisprotocol/oasis-core) version:
-  * [21.3.9](https://github.com/oasisprotocol/oasis-core/releases/tag/v21.3.9)
+  * [21.3.10](https://github.com/oasisprotocol/oasis-core/releases/tag/v21.3.10)
 
 :::info
 
@@ -52,7 +52,7 @@ This section contains parameters for various ParaTimes known to be deployed on t
 ### Cipher ParaTime
 
 * Oasis Core version:
-  * [21.3.9](https://github.com/oasisprotocol/oasis-core/releases/tag/v21.3.9)
+  * [21.3.10](https://github.com/oasisprotocol/oasis-core/releases/tag/v21.3.10)
 * Runtime identifier:
   * `000000000000000000000000000000000000000000000000e199119c992377cb`
 * Runtime binary version:
@@ -69,7 +69,7 @@ Feel free to use other IAS proxies besides the one provided here or [run your ow
 ### Emerald ParaTime
 
 * Oasis Core version:
-  * [21.3.9](https://github.com/oasisprotocol/oasis-core/releases/tag/v21.3.9)
+  * [21.3.10](https://github.com/oasisprotocol/oasis-core/releases/tag/v21.3.10)
 * Runtime identifier:
   * `000000000000000000000000000000000000000000000000e2eaa99fc008f87f`
 * Runtime binary version (or [build your own](https://github.com/oasisprotocol/emerald-paratime/tree/v7.1.0#building)):


### PR DESCRIPTION
This has lived on testnet long enough, testnet is on v22.x, and it has
been a source of confusion.