### PR TITLE
handling-network-upgrades: Describe seamless/dump&restore upgrades

### DIFF
--- a/docs/general/foundation/testnet/README.md
+++ b/docs/general/foundation/testnet/README.md
@@ -36,6 +36,9 @@ Feel free to use other seed nodes besides the one provided here.
 
 * [Oasis Core](https://github.com/oasisprotocol/oasis-core) version:
   * [22.1.6](https://github.com/oasisprotocol/oasis-core/releases/tag/v22.1.6)
+  * To sync from genesis, you need to start with an earlier version first
+    ([read more][handling network upgrades]):
+    * [22.0.3](https://github.com/oasisprotocol/oasis-core/releases/tag/v22.0.3) (until epoch **15056**)
 * [Oasis Rosetta Gateway](https://github.com/oasisprotocol/oasis-rosetta-gateway) version:
   * [2.2.0](https://github.com/oasisprotocol/oasis-rosetta-gateway/releases/tag/v2.2.0)
 
@@ -44,6 +47,8 @@ Feel free to use other seed nodes besides the one provided here.
 The Oasis Node is part of the Oasis Core release.
 
 :::
+
+[handling network upgrades]: ../../run-a-node/maintenance-guides/handling-network-upgrades.md
 
 ## ParaTimes
 

--- a/docs/general/foundation/testnet/upgrade-log.md
+++ b/docs/general/foundation/testnet/upgrade-log.md
@@ -33,9 +33,11 @@ is allow specifying a no-op handler when submitting an upgrade proposal.
 
 :::
 
-:::caution
+:::caution This is not dump & restore upgrade
 
-For this upgrade, do NOT wipe state.
+For this upgrade, **do NOT wipe state**. The new Oasis Core version expects
+the synced state using Oasis Core 22.0.x all the way until the upgrade epoch.
+Read [Handling Network Upgrades] for more info.
 
 :::
 
@@ -63,6 +65,8 @@ is published.
 :::
 
 * If you are running a Rosetta gateway, upgrade it to version [2.2.0].
+
+[Handling Network Upgrades]: ../../run-a-node/maintenance-guides/handling-network-upgrades.md
 
 ### Before Upgrade
 
@@ -355,9 +359,9 @@ Since Oasis Core 21.2.8 is otherwise compatible with the current consensus layer
 
 :::
 
-:::caution
+:::caution This is not dump & restore upgrade
 
-For this upgrade, do NOT wipe state.
+For this upgrade, **do NOT wipe state**.
 
 :::
 
@@ -406,9 +410,9 @@ Since Oasis Core 21.2.4 is otherwise compatible with the current consensus layer
 
 :::
 
-:::caution
+:::caution This is not dump & restore upgrade
 
-For this upgrade, do NOT wipe state.
+For this upgrade, **do NOT wipe state**.
 
 :::
 

--- a/docs/general/run-a-node/upgrade-log.md
+++ b/docs/general/run-a-node/upgrade-log.md
@@ -400,7 +400,7 @@ the [22.1][changelog-22.1] and [22.0][changelog-22.0] sections.
 [changelog-22.0]:
   https://github.com/oasisprotocol/oasis-core/blob/v22.1.3/CHANGELOG.md#220-2022-03-01
 
-## 2021-08-31 (16:00 UTC) - Parameter Update
+## 2021-08-31 (16:00 UTC) - Parameter Update {#2021-08-31-upgrade}
 
 * **Upgrade height:** upgrade is scheduled to happen at epoch **8049.**
 
@@ -557,9 +557,9 @@ Since Oasis Core 21.2.8 is otherwise compatible with the current consensus layer
 
 :::
 
-:::caution
+:::caution This is not dump & restore upgrade
 
-For this upgrade, do NOT wipe state.
+For this upgrade, **do NOT wipe state**.
 
 :::
 
@@ -792,7 +792,7 @@ To do that, just open Ledger Live's Manager and it will prompt you to install ve
 
 :::
 
-## 2021-04-28 (16:00 UTC) - Cobalt Upgrade
+## 2021-04-28 (16:00 UTC) - Cobalt Upgrade {#cobalt-upgrade}
 
 * **Upgrade height:** upgrade is scheduled to happen at epoch **5046.**
 
@@ -910,7 +910,7 @@ Otherwise, external runtime clients wont be able to connect to any storage nodes
 
 :::
 
-## 2020-11-18 (16:00 UTC) - Mainnet
+## 2020-11-18 (16:00 UTC) - Mainnet {#mainnet-upgrade}
 
 * **Block height** when Mainnet Beta network stops: **702000.**
 
@@ -999,7 +999,7 @@ consensus:
     ...
 ```
 
-## 2020-10-01 - Mainnet Beta
+## 2020-10-01 - Mainnet Beta {#mainnet-beta-upgrade}
 
 ### Instructions
 
@@ -1020,7 +1020,7 @@ For more detailed instructions, see the [Handling Network Upgrades](maintenance-
 
 :::
 
-## 2020-09-22 - Mainnet Dry Run
+## 2020-09-22 - Mainnet Dry Run {#mainnet-dry-run}
 
 ### Instructions
 


### PR DESCRIPTION
Adds bullet to testnet parameters on how to sync from genesis:
- https://deploy-preview-96--trusting-archimedes-14c863.netlify.app/general/foundation/testnet/

Revamps Run a Node -> Node Maintenance -> Handling Network Upgrades doc:
- https://deploy-preview-96--trusting-archimedes-14c863.netlify.app/general/run-a-node/maintenance-guides/handling-network-upgrades

Points to the doc above in the testnet's upgrade log too:
- https://deploy-preview-96--trusting-archimedes-14c863.netlify.app/general/foundation/testnet/upgrade-log#instructions