### PR TITLE
Update run-a-paratime-node.mdx

### DIFF
--- a/docs/general/contribute-to-the-network/run-a-paratime-node.mdx
+++ b/docs/general/contribute-to-the-network/run-a-paratime-node.mdx
@@ -46,7 +46,7 @@ confidential smart contracts.
 * **Status:** Deployed on Mainnet and Testnet
 * **Testnet Launch Date:** June 2021
 * **Mainnet Launch Date:** October 2021
-* **Slack Channel:** [#cipher-paratime][connect-with-us]
+* **Discord Channel:** [#cipher-paratime](https://discord.gg/3Hnc99YVGu)
 * **Requires SGX**: Yes
 * **Parameters:**
   * [Mainnet](../oasis-network/network-parameters.md#cipher-paratime)
@@ -92,7 +92,7 @@ EVM smart contracts on the Oasis network.
 * **Status:** Deployed on Mainnet and Testnet
 * **Testnet Launch Date:** October 2021
 * **Mainnet Launch Date:** November 2021
-* **Slack Channel:** [#emerald-paratime][connect-with-us]
+* **Discord Channel:** [#emerald-paratime](https://discord.gg/buFfkxRMBQ)
 * **Requires SGX:** No
 * **Parameters:**
   * [Mainnet](../oasis-network/network-parameters.md#emerald-paratime)


### PR DESCRIPTION
Slack channels were replaced with Discord. URLs point to relevant channels.