### PR TITLE
docs: Add /oasis-core/adr/* -> /adrs/* redirection

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -94,6 +94,19 @@ const config = {
         numberPrefixParser: false,
       },
     ],
+    [
+      '@docusaurus/plugin-client-redirects',
+      {
+        createRedirects(existingPath) {
+          if (existingPath.includes('/adrs')) {
+            return [
+              existingPath.replace('/adrs', '/oasis-core/adr'),
+            ];
+          }
+          return undefined;
+        },
+      },
+    ],
   ],
   themes: [
     [

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@docusaurus/core": "^2.0.0-beta.20",
+    "@docusaurus/plugin-client-redirects": "2.0.0-beta.20",
     "@docusaurus/preset-classic": "^2.0.0-beta.20",
     "@easyops-cn/docusaurus-search-local": "^0.26.0",
     "@mdx-js/react": "^1.6.22",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1310,6 +1310,21 @@
     "@types/react-router-dom" "*"
     react-helmet-async "*"
 
+"@docusaurus/plugin-client-redirects@2.0.0-beta.20":
+  version "2.0.0-beta.20"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-client-redirects/-/plugin-client-redirects-2.0.0-beta.20.tgz#f4bbe5958bbcc7915968c23d99dcfcbfe82df8d2"
+  integrity sha512-YgIDFpr2EDpLwYUtq1t6VD7EOsD3YqA6biXkQmgts1gjFZ1pqVte6Q+tXVzwvL/xR7NdnekevygmS98/IPNePQ==
+  dependencies:
+    "@docusaurus/core" "2.0.0-beta.20"
+    "@docusaurus/logger" "2.0.0-beta.20"
+    "@docusaurus/utils" "2.0.0-beta.20"
+    "@docusaurus/utils-common" "2.0.0-beta.20"
+    "@docusaurus/utils-validation" "2.0.0-beta.20"
+    eta "^1.12.3"
+    fs-extra "^10.1.0"
+    lodash "^4.17.21"
+    tslib "^2.4.0"
+
 "@docusaurus/plugin-content-blog@2.0.0-beta.20":
   version "2.0.0-beta.20"
   resolved "https://registry.yarnpkg.com/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.0.0-beta.20.tgz#7c0d413ac8df9a422a0b3ddd90b77ec491bbda15"


### PR DESCRIPTION
Adds client-side redirects for obsolete oasis-core/adrs/ URLs.

Merge after https://github.com/oasisprotocol/oasis-core/pull/4770 lands in oasis-core/stable-22.1.x branch, because docusaurus doesn't allow duplicate routes (e.g. existing /oasis-core/adr/* pages and redirections from /oasis-core/adr/* to adrs/*).