### PR TITLE
external: Switch oasis-sdk from stable to main branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,7 +5,6 @@
 [submodule "external/oasis-sdk"]
 	path = external/oasis-sdk
 	url = https://github.com/oasisprotocol/oasis-sdk
-	branch = stable/0.2.x
 [submodule "external/oasis-core-ledger"]
 	path = external/oasis-core-ledger
 	url = https://github.com/oasisprotocol/oasis-core-ledger


### PR DESCRIPTION
Temporarily switch oasis-sdk repo from `stable/0.2.x` to `main` to reduce the amount of backport docs commits.