### PR TITLE
sidebars: Add cipher confidential tutorial

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -152,6 +152,7 @@ const config = {
       prism: {
         theme: lightCodeTheme,
         darkTheme: darkCodeTheme,
+        additionalLanguages: ['rust', 'toml'],
       },
     }),
 };

--- a/sidebarsOasisSdk.js
+++ b/sidebarsOasisSdk.js
@@ -13,12 +13,9 @@ const sidebars = {
       label: 'Smart Contracts',
       collapsible: false,
       items: [
-        {
-          type: 'doc',
-          id: 'contract/getting-started',
-          label: 'Build a Smart Contract',
-        },
+        'contract/getting-started',
         'contract/hello-world',
+        'contract/confidential-smart-contract',
       ],
     },
     {
@@ -26,11 +23,7 @@ const sidebars = {
       label: 'Runtimes',
       collapsible: false,
       items: [
-        {
-          type: 'doc',
-          id: 'runtime/getting-started',
-          label: 'Build a Runtime',
-        },
+        'runtime/getting-started',
         'runtime/minimal-runtime',
         'runtime/modules',
         'runtime/reproducibility',


### PR DESCRIPTION
- Adds confidential smart contracts entry to sidebar: https://deploy-preview-130--trusting-archimedes-14c863.netlify.app/oasis-sdk/contract/confidential-smart-contract
- bumps oasis-sdk to include it
- enables rust and toml syntax highlighter