### PR TITLE
docs/general: Rework GitBook-specific descriptions into general ones

### DIFF
--- a/docs/general/community-resources/community-hub.md
+++ b/docs/general/community-resources/community-hub.md
@@ -1,11 +1,8 @@
----
-description: >-
-  This page serves as a hub for Oasis community members, featuring info about
-  upcoming events and initiatives, ways to get involved with the community and
-  earn ROSE tokens, and many other resources.
----
-
 # Community Hub
+
+This page serves as a hub for Oasis community members, featuring info about
+upcoming events and initiatives, ways to get involved with the community and
+earn ROSE tokens, and many other resources.
 
 ## 🎉 Welcome to the Oasis Community
 

--- a/docs/general/community-resources/token-delivery-and-kyc.md
+++ b/docs/general/community-resources/token-delivery-and-kyc.md
@@ -1,9 +1,3 @@
----
-description: >-
-  This page provides an overview of the token delivery and KYC process for
-  anyone receiving ROSE tokens from the Oasis Foundation.
----
-
 # Token Delivery & KYC Guide
 
 If you're visiting this page, you may have recently earned ROSE tokens via the Community Cup program, the Ambassador Rewards program, or a recent hackathon. Congratulations!

--- a/docs/general/contribute-to-the-network/run-a-paratime-node.mdx
+++ b/docs/general/contribute-to-the-network/run-a-paratime-node.mdx
@@ -1,13 +1,12 @@
----
-description: >-
-  Overview of the requirements to become a compute node on a ParaTime connected
-  to the Oasis Network.
----
-
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 # Run a ParaTime Node
+
+This guide provides an overview of the requirements to become a compute node for
+a ParaTime connected to the Oasis Network.
+
+## About Oasis Network
 
 The Oasis Network has two main components, the Consensus Layer and the ParaTime
 Layer.
@@ -18,6 +17,8 @@ Layer.
    representing a replicated compute environment with shared state.
 
 ![](../images/architecture/technology_scalability.svg)
+
+## Operating ParaTimes
 
 Operating a ParaTime requires the participation of node operators who
 contribute nodes to the committee in exchange for rewards.

--- a/docs/general/contribute-to-the-network/run-validator.md
+++ b/docs/general/contribute-to-the-network/run-validator.md
@@ -1,10 +1,9 @@
----
-description: >-
-  Overview of the technical setup and stake requirements to become a validator
-  on the consensus layer of the Oasis Network.
----
-
 # Run a Consensus Validator Node
+
+This guide provides an overview of the technical setup and stake requirements to
+become a validator on the Consensus layer of the Oasis Network.
+
+## About Oasis Network
 
 [Oasis Network](../oasis-network/overview.md)'s Consensus Layer is a decentralised set of validator nodes that maintain a proof-of-stake blockchain.
 

--- a/docs/general/developer-resources/emerald-paratime/integrating-band-oracle-smart-contract.md
+++ b/docs/general/developer-resources/emerald-paratime/integrating-band-oracle-smart-contract.md
@@ -1,10 +1,7 @@
----
-description: >-
-  How to query the Band Protocol reference data smart contract from another
-  Solidity smart contract on Emerald.
----
-
 # Integrating BAND oracle smart contract
+
+This guide will explain how to query the Band Protocol reference data smart
+contract from another Solidity smart contract on Emerald.
 
 ### What is the Band Protocol?
 

--- a/docs/general/developer-resources/emerald-paratime/writing-dapps-on-emerald.md
+++ b/docs/general/developer-resources/emerald-paratime/writing-dapps-on-emerald.md
@@ -1,13 +1,11 @@
----
-description: How to write and deploy a dApp to Oasis Emerald
----
-
 # Writing dApps on Emerald
 
 This tutorial will show you how to set up dApp development environment for
-Emerald. We will walk you through the Hardhat and Truffle configuration and -
-for those who prefer a simpler web-only interface - the Remix IDE. Oasis
-Emerald exposes an EVM-compatible interface so writing dApps isn't much
+Emerald to be able to write and deploy dApps on Oasis Emerald.
+
+We will walk you through the Hardhat and Truffle configuration and -
+for those who prefer a simpler web-only interface - the Remix IDE.
+Oasis Emerald exposes an EVM-compatible interface so writing dApps isn't much
 different compared to the original Ethereum Network!
 
 ## Oasis Consensus Layer and Emerald ParaTime

--- a/docs/general/faq/oasis-network-faq.md
+++ b/docs/general/faq/oasis-network-faq.md
@@ -1,11 +1,11 @@
----
-description: >-
-  We'll use this page to answer some of the most frequently asked questions we
-  receive about the Oasis Network. This page will constantly be updated with new
-  questions and responses.
----
-
 # Oasis Network FAQ
+
+This page tries to answer some of the most frequently asked questions about the
+Oasis Network.
+
+:::info
+This page will constantly be updated with new questions and responses.
+:::
 
 ## **Overview**
 

--- a/docs/general/foundation/delegation-policy.md
+++ b/docs/general/foundation/delegation-policy.md
@@ -1,13 +1,11 @@
----
-description: This page describe the Oasis Protocol Foundation's Delegation Policy.
----
-
 # Delegation Policy
 
 Oasis Protocol Foundation delegates ROSE tokens to node operators based on their
 participation in the Oasis Mainnet, Testnet and ParaTimes on the network,
 node reliability and performance, community engagement and overall support of
 the network.
+
+This page describes the Oasis Protocol Foundation's Delegation Policy.
 
 ## Requirements for Receiving Delegations
 

--- a/docs/general/foundation/testnet/README.md
+++ b/docs/general/foundation/testnet/README.md
@@ -1,10 +1,7 @@
----
-description: >-
-  These are the current parameters for the Testnet, a test-only network for
-  testing out upcoming features and changes to the protocol.
----
-
 # The Testnet
+
+These are the current parameters for the Testnet, a test-only network for
+testing out upcoming features and changes to the protocol.
 
 :::danger
 

--- a/docs/general/foundation/testnet/upgrade-log.md
+++ b/docs/general/foundation/testnet/upgrade-log.md
@@ -1,10 +1,10 @@
----
-description: >-
-  For each upgrade of the Testnet network, we will track important changes for
-  node operators' deployments.
----
-
 # Upgrade Log
+
+
+For each upgrade of the Testnet network, we are tracking important changes for
+node operators' deployments.
+
+They are enumerated and explained in this document.
 
 ## 2022-04-04 Upgrade
 

--- a/docs/general/manage-tokens/faq.md
+++ b/docs/general/manage-tokens/faq.md
@@ -1,10 +1,7 @@
----
-description: >-
-  This documents answers frequently asked questions about Oasis Wallets and 3rd
-  party wallets & custody providers
----
-
 # Frequently Asked Questions
+
+This documents answers frequently asked questions about Oasis Wallets and 3rd
+party wallets & custody providers supporting ROSE tokens.
 
 ### How can I transfer ROSE tokens from my [BitPie wallet](holding-rose-tokens/bitpie-wallet.md) to my Oasis Wallet?
 

--- a/docs/general/manage-tokens/holding-rose-tokens/README.md
+++ b/docs/general/manage-tokens/holding-rose-tokens/README.md
@@ -1,13 +1,10 @@
----
-description: >-
-  This documentation provides an overview of 3rd party custody and wallet
-  solutions supported by the Oasis Network for managing ROSE tokens.
----
-
 import DocCardList from '@theme/DocCardList';
 import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
 
 # 3rd Party Custody & Wallets
+
+This document provides an overview of 3rd party custody and wallet solutions
+supported by the Oasis Network for managing ROSE tokens.
 
 ## Quick Navigation
 

--- a/docs/general/manage-tokens/holding-rose-tokens/bitpie-wallet.md
+++ b/docs/general/manage-tokens/holding-rose-tokens/bitpie-wallet.md
@@ -1,11 +1,8 @@
----
-description: >-
-  This page provides an overview of how you can set up your Bitpie Wallet and
-  then use it to generate an Oasis wallet address as well as receive and
-  transfer ROSE tokens on the Oasis Mainnet.
----
-
 # Bitpie Mobile Wallet
+
+This guide will teach you how to set up your Bitpie Wallet and use it to
+generate an Oasis wallet address as well as receive and transfer ROSE tokens on
+the Oasis Mainnet.
 
 ## What is Bitpie?
 

--- a/docs/general/manage-tokens/how-to-transfer-eth-erc20-to-emerald-paratime.md
+++ b/docs/general/manage-tokens/how-to-transfer-eth-erc20-to-emerald-paratime.md
@@ -1,10 +1,8 @@
----
-description: >-
-  Guide on bringing your assets, i.e. ETH, USDC, USDT, from Ethereum, BSC,
-  Polygon or Avalanche to Emerald ParaTime using the Wormhole token bridge.
----
-
 # How to Transfer ETH/ERC20 to Emerald ParaTime
+
+This guide will walk you through bringing your assets, i.e. ETH, USDC, USDT,
+from Ethereum, BSC, Polygon or Avalanche networks to the Emerald ParaTime using
+the Wormhole token bridge.
 
 ## About
 

--- a/docs/general/manage-tokens/how-to-transfer-rose-into-emerald-paratime.mdx
+++ b/docs/general/manage-tokens/how-to-transfer-rose-into-emerald-paratime.mdx
@@ -1,13 +1,11 @@
----
-description: >-
-  Transferring ROSE from Oasis Consensus to Emerald ParaTime using the Oasis
-  Wallet Browser Extension.
----
-
 import DocCard from '@theme/DocCard';
 import {findSidebarItem} from '@site/src/sidebarUtils';
 
 # How to Transfer ROSE into Emerald ParaTime
+
+This guide will walk you through transferring ROSE tokens from an Oasis
+Consensus layer account into the Emerald ParaTime using the Oasis Wallet -
+Browser Extension.
 
 ## About
 

--- a/docs/general/manage-tokens/oasis-wallets/README.mdx
+++ b/docs/general/manage-tokens/oasis-wallets/README.mdx
@@ -1,14 +1,11 @@
----
-description: >-
-  This document provides an overview of how to use the official Oasis Wallets: a
-  non-custodial web wallet and a non-custodial browser extension that connect to
-  the Oasis Network.
----
-
 import DocCardList from '@theme/DocCardList';
 import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
 
 # Oasis Wallets
+
+This document provides an overview of how to use the official Oasis Wallets: a
+non-custodial web wallet and a non-custodial browser extension that connect to
+the Oasis Network.
 
 ## **What are the official Oasis Wallets?**
 

--- a/docs/general/manage-tokens/oasis-wallets/browser-extension.md
+++ b/docs/general/manage-tokens/oasis-wallets/browser-extension.md
@@ -1,10 +1,7 @@
----
-description: >-
-  Oasis Foundation-managed official non-custodial browser extension wallet for
-  the Oasis Network.
----
-
 # Browser Extension
+
+Oasis Foundation-managed official non-custodial browser extension wallet for the
+Oasis Network.
 
 ## **How to use the Oasis Wallet - Browser Extension**
 

--- a/docs/general/manage-tokens/oasis-wallets/web.md
+++ b/docs/general/manage-tokens/oasis-wallets/web.md
@@ -1,10 +1,7 @@
----
-description: >-
-  Oasis Foundation-managed official non-custodial web wallet for the Oasis
-  Network.
----
-
 # Web
+
+Oasis Foundation-managed official non-custodial web wallet for the Oasis
+Network.
 
 ## How to use the Oasis Wallet - Web
 

--- a/docs/general/manage-tokens/staking-and-delegating.md
+++ b/docs/general/manage-tokens/staking-and-delegating.md
@@ -1,10 +1,8 @@
----
-description: >-
-  Staking and Delegation on the Oasis Network is a wonderful way to hold your
-  ROSE tokens. A few key resources to get started!
----
-
 # Staking and Delegating
+
+Staking and Delegation on the Oasis Network is a wonderful way to hold your ROSE
+tokens.
+Here are a few key resources to get started!
 
 ## Rewards and Tokenomics
 

--- a/docs/general/oasis-network/genesis-doc.md
+++ b/docs/general/oasis-network/genesis-doc.md
@@ -1,8 +1,6 @@
----
-description: This document provides an overview of the Oasis Network's genesis document.
----
-
 # Genesis Document
+
+This document provides an overview of the Oasis Network's genesis document.
 
 ## What is a Genesis Document?
 

--- a/docs/general/oasis-network/network-parameters.md
+++ b/docs/general/oasis-network/network-parameters.md
@@ -1,10 +1,7 @@
----
-description: >-
-  This page is meant to be kept up to date with the information from the
-  currently released network.
----
-
 # Network Parameters
+
+This page provides up to date information for the currently running Oasis
+Network.
 
 These are the current parameters for the Mainnet:
 

--- a/docs/general/oasis-network/overview.md
+++ b/docs/general/oasis-network/overview.md
@@ -1,7 +1,3 @@
----
-description: An overview of Oasis Network Architecture and Key Technological Benefits
----
-
 # Overview of the Oasis Network
 
 The Oasis Network is a Layer 1 decentralized blockchain network designed to be uniquely scalable, privacy-first and versatile.

--- a/docs/general/run-a-node/prerequisites/stake-requirements.md
+++ b/docs/general/run-a-node/prerequisites/stake-requirements.md
@@ -1,32 +1,29 @@
----
-description: >-
-  Overview of the stake requirements to become a validator
-  on the consensus layer of the Oasis Network.
----
-
 # Stake Requirements
+
+This page provides an overview of the stake requirements to become a validator
+on the consensus layer of the Oasis Network.
 
 ## Mainnet
 
-To become a validator on the Oasis Network, you will need to have enough 
-tokens staked in your escrow account.  
+To become a validator on the Oasis Network, you will need to have enough
+tokens staked in your escrow account.
 
 Currently, you are going to need:
 
-* 100 ROSE staked for your entity's registration since that is the 
+* 100 ROSE staked for your entity's registration since that is the
 [staking thresholds].
-* 100 ROSE staked for your validator node's registration since that is the 
+* 100 ROSE staked for your validator node's registration since that is the
 [staking thresholds].
-* If you want to be part of the active validator set, you will need enough 
-ROSE staked --  this means you will have to be one of the top 120 entities 
-by stake. You can check out current top 120 entities on the blockchain explorer 
+* If you want to be part of the active validator set, you will need enough
+ROSE staked --  this means you will have to be one of the top 120 entities
+by stake. You can check out current top 120 entities on the blockchain explorer
 such as [Oasis Scan].
 
-For more information about obtaining information on your entity's account, see 
+For more information about obtaining information on your entity's account, see
 the [Account Get Info] doc.
 
 Staking thresholds may change in the future. Read [Common staking info] chapter,
-to learn how to check the current network thresholds directly from the 
+to learn how to check the current network thresholds directly from the
 `oasis-node`.
 
 [staking thresholds]: ../../oasis-network/genesis-doc.md#staking-thresholds
@@ -36,7 +33,7 @@ to learn how to check the current network thresholds directly from the
 
 :::info
 
-To determine if you are eligible to receive a delegation from the Oasis Protocol 
+To determine if you are eligible to receive a delegation from the Oasis Protocol
 Foundation, see the [Delegation Policy] document.
 
 [Delegation Policy]: ../../foundation/delegation-policy.md
@@ -45,7 +42,7 @@ Foundation, see the [Delegation Policy] document.
 
 :::info
 
-The size of the consensus committee (i.e. the validator set) is configured by 
+The size of the consensus committee (i.e. the validator set) is configured by
 the [**max_validators** consensus parameter].
 
 [**max_validators** consensus parameter]: ../../oasis-network/genesis-doc.md#consensus
@@ -54,8 +51,8 @@ the [**max_validators** consensus parameter].
 
 ## Testnet
 
-For the Testnet you are going to need TEST tokens. You can receive a limited 
-number of TEST by using our [Oasis Network Testnet Faucet][faucet-testnet]. For 
+For the Testnet you are going to need TEST tokens. You can receive a limited
+number of TEST by using our [Oasis Network Testnet Faucet][faucet-testnet]. For
 more tokens please contact us at our official [Discord #testnet channel]
 [discord-testnet].
 

--- a/docs/general/run-a-node/prerequisites/system-configuration.mdx
+++ b/docs/general/run-a-node/prerequisites/system-configuration.mdx
@@ -1,13 +1,10 @@
----
-description: >-
-  This page describes changes that should be made to the configuration of the
-  system where you are running the Oasis Node instance.
----
-
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 # System Configuration
+
+This page describes changes that should be made to the configuration of the
+system where you are running an Oasis Node instance.
 
 ## File Descriptor Limit
 

--- a/docs/general/run-a-node/set-up-your-node/run-a-paratime-client-node.mdx
+++ b/docs/general/run-a-node/set-up-your-node/run-a-paratime-client-node.mdx
@@ -1,7 +1,3 @@
----
-description: This page describes how to run a ParaTime client node on the Oasis Network.
----
-
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
@@ -192,7 +188,7 @@ genesis:
   file: /node/etc/genesis.json
 
 consensus:
-  tendermint:    
+  tendermint:
     p2p:
       # List of seed nodes to connect to.
       # NOTE: You can add additional seed nodes to this list if you want.

--- a/docs/general/run-a-node/set-up-your-node/run-a-paratime-node.mdx
+++ b/docs/general/run-a-node/set-up-your-node/run-a-paratime-node.mdx
@@ -1,7 +1,3 @@
----
-description: This page describes how to run a ParaTime node on the Oasis Network.
----
-
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
@@ -325,7 +321,7 @@ consensus:
       # NOTE: If you are using the Sentry node setup, this option should be
       # omitted.
       external_address: tcp://{{ external_address }}:26656
-    
+
     p2p:
       # List of seed nodes to connect to.
       # NOTE: You can add additional seed nodes to this list if you want.

--- a/docs/general/run-a-node/set-up-your-node/run-an-ias-proxy.md
+++ b/docs/general/run-a-node/set-up-your-node/run-an-ias-proxy.md
@@ -1,9 +1,3 @@
----
-description: >-
-  This page describes how to run an Intel Attestation Service (IAS) Proxy node
-  on the Oasis Network.
----
-
 # Run an IAS Proxy
 
 This guide will cover setting up an [Intel Attestation Service (IAS)](https://software.intel.com/content/www/us/en/develop/download/intel-sgx-intel-epid-provisioning-and-attestation-services.html) Proxy node for the Oasis Network. This guide assumes some basic knowledge on the use of command line tools.
@@ -83,6 +77,6 @@ The TLS public key required for connecting to the IAS Proxy is located in the co
 --ias.proxy.address <IAS_PROXY_PUBLIC_KEY>@<EXTERNAL_IP>:8650
 ```
 
-[  
+[
 ](/general/run-a-node/set-up-your-node/run-non-validator)
 

--- a/docs/general/run-a-node/set-up-your-node/run-non-validator.md
+++ b/docs/general/run-a-node/set-up-your-node/run-non-validator.md
@@ -1,7 +1,3 @@
----
-description: This page describes how to run a non-validator node on the Oasis Network.
----
-
 # Run a Non-validator Node
 
 :::info

--- a/docs/general/run-a-node/set-up-your-node/run-seed-node.md
+++ b/docs/general/run-a-node/set-up-your-node/run-seed-node.md
@@ -1,7 +1,3 @@
----
-description: This page describes how to run a seed node on the Oasis Network.
----
-
 # Run a Seed Node
 
 This guide will cover setting up a seed node for the Oasis Network. This guide assumes some basic knowledge on the use of command line tools.

--- a/docs/general/run-a-node/set-up-your-node/run-validator.md
+++ b/docs/general/run-a-node/set-up-your-node/run-validator.md
@@ -1,7 +1,3 @@
----
-description: This page describes how to run a validator node on the Oasis Network.
----
-
 # Run a Validator Node
 
 :::info
@@ -607,16 +603,16 @@ Note that in order to be elected in the validator set you need to have enough st
 
 :::
 
-Congratulations, if you made it this far, you've properly connected your node 
+Congratulations, if you made it this far, you've properly connected your node
 to the network and became a validator on the Oasis Network.
 
 ## Oasis Metadata Registry
 
-For the final touch, you can add some metadata about your entity to the 
-[Metadata Registry]. The Metadata Registry is the same for the Mainnet and 
-the Testnet. The metadata consists of your entity name, email, Keybase handle, 
-Twitter handle, etc. This information is also used by third party applications. 
-For example [Oasis Scan] fetches your image from Keybase and uses it as the node 
+For the final touch, you can add some metadata about your entity to the
+[Metadata Registry]. The Metadata Registry is the same for the Mainnet and
+the Testnet. The metadata consists of your entity name, email, Keybase handle,
+Twitter handle, etc. This information is also used by third party applications.
+For example [Oasis Scan] fetches your image from Keybase and uses it as the node
 operator's avatar.
 
 [Metadata Registry]: https://github.com/oasisprotocol/metadata-registry

--- a/docs/general/run-a-node/upgrade-log.md
+++ b/docs/general/run-a-node/upgrade-log.md
@@ -1,10 +1,9 @@
----
-description: >-
-  For each upgrade of the network, we will track important changes for node
-  operators' deployments.
----
-
 # Upgrade Log
+
+For each upgrade of the Oasis Network, we are tracking important changes for
+node operators' deployments.
+
+They are enumerated and explained in this document.
 
 ## 2022-04-11 (8:30 UTC) - Damask Upgrade {#damask-upgrade}
 


### PR DESCRIPTION
Previously, using GitBook-specific syntax for descriptions meant that they were not shown anywhere with Docusaurus.