### PR TITLE
docs: Fix anchorage.com broken link

### DIFF
--- a/docs/general/manage-tokens/holding-rose-tokens/custody-providers.md
+++ b/docs/general/manage-tokens/holding-rose-tokens/custody-providers.md
@@ -24,7 +24,7 @@ Anchorage is an advanced digital asset platform, with a solution designed to mee
 
 * **Delegation options:** Anchorage allows delegation to any validator running a node on the Oasis Network.
 * **Min holding:** Minimum custody requirements. Suitable for larger token holders.
-* **Sign up:** Please sign up [here](https://web.anchorage.com/anchorage-oasis).
+* **Sign up:** Please sign up [here](https://www.anchorage.com/get-started/).
 
 ### [Finoa](https://finoa.io)
 


### PR DESCRIPTION
anchorage.com redesigned their website and the existing https://web.anchorage.com/anchorage-oasis became broken. Fix link to point to the new sign-up page.