### PR TITLE
terminology.md: Fix indentation

### DIFF
--- a/docs/general/manage-tokens/terminology.md
+++ b/docs/general/manage-tokens/terminology.md
@@ -1,48 +1,73 @@
 # Terminology
 
-### Account
+## Account
 
 A staking **account** is an entry in the staking ledger.
 
 It has two (sub)accounts:
 
-*   **General account.**
+- **General account**
+  
+  It is used to keep the funds that are freely available to the account owner
+  to transfer, delegate/stake, pay gas fees, etc.
 
-    It is used to keep the funds that are freely available to the account owner to transfer, delegate/stake, pay gas fees, ...
-*   **Escrow account**.
+- **Escrow account**
 
-    It are used to keep the funds needed for specific consensus-layer operations (e.g. registering and running nodes, staking and delegation of tokens, ...).
+  It is used to keep the funds needed for specific consensus-layer operations
+  (e.g. registering and running nodes, staking and delegation of tokens, ...).
+  
+  To simplify accounting, each escrow results in the source account being
+  issued shares which can be converted back into staking tokens during the
+  reclaim escrow operation. Reclaiming escrow does not complete immediately,
+  but may be subject to a debonding period during which the tokens still remain
+  escrowed.
 
+## Address
 
+A staking account **address** is represented by a truncated hash of a
+corresponding entity's public key, prefixed by a 1 byte address version.
 
-    To simplify accounting, each escrow results in the source account being issued shares which can be converted back into staking tokens during the reclaim escrow operation. Reclaiming escrow does not complete immediately, but may be subject to a debonding period during which the tokens still remain escrowed.
+It uses [Bech32 encoding] for text serialization with `oasis` as its human
+readable part (HRP) prefix.
 
-### Address
+## Delegation
 
-A staking account **address** is represented by a truncated hash of a corresponding entity's public key, prefixed by a 1 byte address version.
+You can **delegate** your tokens by submitting an **escrow** transaction that
+deposits a specific number of tokens into someone else’s escrow account (as
+opposed to **staking** tokens, which usually refers to depositing tokens into
+your own escrow account).
 
-It uses [Bech32 encoding](https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki#bech32) for text serialization with `oasis` as its human readable part (HRP) prefix.
+In other words, delegating your tokens is equivalent to staking your tokens in
+someone else's validator node. Delegating your tokens can give you the
+opportunity to participate in the Oasis Network's proof-of-stake consensus
+system and earn rewards via someone else's validator node.
 
-### Delegation
+## Staking
 
-You can **delegate** your tokens by submitting an **escrow** transaction that deposits a specific number of tokens into someone else’s escrow account (as opposed to **staking** tokens, which usually refers to depositing tokens into your own escrow account).
+You can stake your tokens by submitting an **escrow** transaction that deposits
+a specific number of tokens into your escrow account.
 
-In other words, delegating your tokens is equivalent to staking your tokens in someone else's validator node. Delegating your tokens can give you the opportunity to participate in the Oasis Network's proof-of-stake consensus system and earn rewards via someone else's validator node.
+## Rewards
 
-### Staking
+By delegating your tokens to someone else's node, you can earn a portion of the
+rewards earned by that node through its participation in the Oasis Network.
 
-You can stake your tokens by submitting an **escrow** transaction that deposits a specific number of tokens into your escrow account.
+## Commission
 
-### Rewards
+Node operators collect **commissions** when their node earns a
+**staking reward** for delegators. A validator node earns a staking reward for
+participating in the consensus protocol each epoch. The **commission rate** is
+a fraction of the staking reward.
 
-By delegating your tokens to someone else's node, you can earn a portion of the rewards earned by that node through its participation in the Oasis Network.
+For example, if our validator node earns a reward of 0.007 tokens, 0.0035
+tokens are added to the escrow pool (increasing the value of our escrow pool
+shares uniformly), and 0.0035 tokens are given to us (issuing us new shares as
+if we manually deposited them).
 
-### Commission
+## Slashing
 
-Node operators collect **commissions** when their node earns a **staking reward** for delegators. A validator node earns a staking reward for participating in the consensus protocol each epoch. The **commission rate** is a fraction of the staking reward.
+Your delegated tokens can be slashed if the node that you delegated your tokens
+to gets slashed for double signing.
 
-For example, if our validator node earns a reward of 0.007 tokens, 0.0035 tokens are added to the escrow pool (increasing the value of our escrow pool shares uniformly), and 0.0035 tokens are given to us (issuing us new shares as if we manually deposited them).
-
-### Slashing
-
-Your delegated tokens can be slashed if the node that you delegated your tokens to gets slashed for double signing.
+[Bech32 encoding]:
+  https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki#bech32


### PR DESCRIPTION
Fixes wrong indentation caused when migrating from gitbook.

Preview: https://deploy-preview-217--trusting-archimedes-14c863.netlify.app/general/manage-tokens/terminology