### PR TITLE
docs: Rename dapp -> dApp for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ link checker in `package.json`._
 ### Documentation structure
 
 `docs` folder contains markdown files of the documentation. Each subfolder
-represents one of the top-level chapter (general, node, dapp, paratime, core
+represents one of the top-level chapter (general, node, dApp, paratime, core
 etc.).
 
 Some top-level chapter may contain markdown files or folders hosted and

--- a/docs/README.mdx
+++ b/docs/README.mdx
@@ -40,7 +40,7 @@ queries on the network.
     findSidebarItem('/node/run-your-node'),
 ]} />
 
-## dapp and ParaTime Developers
+## DApps and ParaTime Developers
 
 These two sections are focused on developers building applications on top of
 the Oasis Network. Smart contract developers will be interested in the

--- a/docs/dapp/README.mdx
+++ b/docs/dapp/README.mdx
@@ -4,10 +4,10 @@ import {findSidebarItem} from '@site/src/sidebarUtils';
 # Overview
 
 This chapter contains developer resources related to the implementation of
-dapps on the Oasis Network.
+dApps on the Oasis Network.
 
 Each ParaTime has its unique features and requires specific development
-environment for writing dapps. Read the related sections below to learn more.
+environment for writing dApps. Read the related sections below to learn more.
 
 <DocCardList items={[
     findSidebarItem('/dapp/emerald/'),

--- a/docs/dapp/emerald/README.mdx
+++ b/docs/dapp/emerald/README.mdx
@@ -8,7 +8,7 @@ The Emerald ParaTime is our official EVM Compatible ParaTime providing smart con
 As the official EVM compatible ParaTime on the Oasis Network, Emerald allows for:
 
 * Full EVM compatibility
-* Easy integration with EVM-based dapps, such as DeFi, NFT, Metaverse and crypto gaming
+* Easy integration with EVM-based dApps, such as DeFi, NFT, Metaverse and crypto gaming
 * Scalability — increased throughput of transactions
 * Low-cost — 99%+ lower fees than Ethereum
 * Cross-chain bridge to enable cross-chain interoperability (upcoming)

--- a/docs/dapp/emerald/writing-dapps-on-emerald.md
+++ b/docs/dapp/emerald/writing-dapps-on-emerald.md
@@ -1,11 +1,11 @@
-# Writing dapps on Emerald
+# Writing dApps on Emerald
 
-This tutorial will show you how to set up dapp development environment for
-Emerald to be able to write and deploy dapps on Oasis Emerald.
+This tutorial will show you how to set up dApp development environment for
+Emerald to be able to write and deploy dApps on Oasis Emerald.
 
 We will walk you through the Hardhat and Truffle configuration and -
 for those who prefer a simpler web-only interface - the Remix IDE.
-Oasis Emerald exposes an EVM-compatible interface so writing dapps isn't much
+Oasis Emerald exposes an EVM-compatible interface so writing dApps isn't much
 different compared to the original Ethereum Network!
 
 ## Oasis Consensus Layer and Emerald ParaTime
@@ -24,7 +24,7 @@ hex-encoded addresses (e.g. `0x90adE3B7065fa715c7a150313877dF1d33e777D5`). The
 underlying algorithm for signing the transactions is [Ed25519] on the Consensus
 layer and both [Ed25519] and [ECDSA] in Emerald. The Ed25519 scheme is used
 mostly by the Emerald compute nodes for managing their computation rewards. For
-signing your dapp-related transactions on Emerald you will probably want to use
+signing your dApp-related transactions on Emerald you will probably want to use
 ECDSA since this is the de facto scheme supported by Ethereum wallets and
 libraries.
 
@@ -78,7 +78,7 @@ ParaTime.
 
 ## Running Private Oasis Network Locally
 
-For convenient development and testing of your dapps the Oasis team prepared
+For convenient development and testing of your dApps the Oasis team prepared
 the [oasisprotocol/emerald-dev][emerald-dev] Docker image which brings you a complete Oasis
 stack to your desktop. This network is isolated from the Mainnet or Testnet and
 consists of:
@@ -129,7 +129,7 @@ WARNING: Emerald is running in ephemeral mode. The chain state will be lost afte
 Listening on http://localhost:8545 and ws://localhost:8546
 ```
 
-Those familiar with local dapp environments will find the output above similar
+Those familiar with local dApp environments will find the output above similar
 to `geth --dev` or `ganache-cli` commands or the `geth-dev-assistant` npm
 package. [emerald-dev] will spin up a private Oasis Network locally, generate
 and populate test accounts and make the following Web3 endpoints available for
@@ -159,10 +159,10 @@ will be lost after you quit the Docker container!
 
 [emerald-dev]: https://hub.docker.com/r/oasisprotocol/emerald-dev
 
-## Create dapp on Emerald with Hardhat
+## Create dApp on Emerald with Hardhat
 
-Let's begin writing our dapp with Hardhat. We will lay out a base for a modern
-dapp including TypeScript bindings for tests and later for the frontend
+Let's begin writing our dApp with Hardhat. We will lay out a base for a modern
+dApp including TypeScript bindings for tests and later for the frontend
 application.
 
 First, make sure you installed [Node.js] and that you have `npm` and `npx`
@@ -175,7 +175,7 @@ npx hardhat init
 Select the `Create an advanced sample project that uses TypeScript` option and
 enter the root directory for your project. You can leave other options as
 default. After a while Hardhat will finish downloading the dependencies and
-create a simple greeter dapp.
+create a simple greeter dApp.
 
 To compile, deploy and test the smart contract of your sample project locally,
 move to your project directory and type:
@@ -321,7 +321,7 @@ Greeter deployed to: 0x6e8e9e0DBCa4EF4a65eBCBe4032e7C2a6fb7C623
 [Node.js]: https://nodejs.org
 [ethers.js]: https://docs.ethers.io/v5/
 
-## Create dapp on Emerald with Truffle
+## Create dApp on Emerald with Truffle
 
 Truffle and its accompanying [web3.js] library is another popular smart
 contract deployment tool. Let's follow [the official Truffle's quickstart
@@ -563,7 +563,7 @@ In the output above, the MetaCoin contract has been successfully deployed to
 [web3.js]: https://web3js.readthedocs.io/en/v1.5.2/
 [truffle-quickstart]: https://trufflesuite.com/docs/truffle/quickstart.html
 
-## Create dapp on Emerald with Remix - Ethereum IDE
+## Create dApp on Emerald with Remix - Ethereum IDE
 
 [Remix] is a popular web IDE for swift development, deployment and testing
 smart contracts on the Ethereum Network. We will use it in combination with

--- a/docs/dapp/sapphire/README.mdx
+++ b/docs/dapp/sapphire/README.mdx
@@ -11,13 +11,13 @@ Sapphire allows for:
 
 * Confidential state, end-to-end encryption, confidential randomness
 * EVM compatibility
-* Easy integration with EVM-based dapps, such as DeFi, NFT, Metaverse and
+* Easy integration with EVM-based dApps, such as DeFi, NFT, Metaverse and
   crypto gaming
 * Scalability — increased throughput of transactions
 * Low-cost — 99%+ lower fees than Ethereum
 * Cross-chain bridge to enable cross-chain interoperability (upcoming)
 
-If you are not bound to EVM and you wish to develop dapps with more
+If you are not bound to EVM and you wish to develop dApps with more
 fine-grained confidentiality, check out the
 [Cipher ParaTime](../cipher/README.mdx).
 

--- a/docs/dapp/sapphire/guide.md
+++ b/docs/dapp/sapphire/guide.md
@@ -1,5 +1,5 @@
 ---
-description: Guide to creating secure dapps on Sapphire
+description: Guide to creating secure dApps on Sapphire
 ---
 
 # Guide
@@ -7,14 +7,14 @@ description: Guide to creating secure dapps on Sapphire
 This page mainly describes the differences between Sapphire and Ethereum
 since there are a number of excellent tutorials on developing for Ethereum.
 If you don't know where to begin, the [Hardhat tutorial], [Solidity docs], and
-[Emerald dapp tutorial] are great places to start. You can continue following
+[Emerald dApp tutorial] are great places to start. You can continue following
 this guide once you've set up your development environment and have deployed
 your contract to a non-confidential EVM network (e.g., Ropsten, Emerald).
 
 
 [Hardhat tutorial]: https://hardhat.org/tutorial
 [Solidity docs]: https://docs.soliditylang.org/en/v0.8.15/solidity-by-example.html
-[Emerald dapp tutorial]: ../emerald/writing-dapps-on-emerald.md
+[Emerald dApp tutorial]: ../emerald/writing-dapps-on-emerald.md
 
 ## Oasis Consensus Layer and Sapphire ParaTime
 
@@ -83,7 +83,7 @@ but we think that you'll like them:
   requiring a transaction to be posted on-chain.
 
 In addition to confidentiality, you get a few extra benefits including the ability to generate private
-entropy, and make signatures on-chain. An example of a dapp that uses both is a HSM contract
+entropy, and make signatures on-chain. An example of a dApp that uses both is a HSM contract
 that generates an Ethereum wallet and signs transactions sent to it via transactions.
 
 Otherwise Sapphire is like Emerald, which is like a fast, cheap Ethereum.
@@ -91,7 +91,7 @@ Otherwise Sapphire is like Emerald, which is like a fast, cheap Ethereum.
 ## Integrating Sapphire
 
 Once ROSE tokens are [deposited into Sapphire], it should be painless for users to begin
-using dapps. To achieve this ideal user experience, we have to modify the dapp a little,
+using dApps. To achieve this ideal user experience, we have to modify the dApp a little,
 but it's made simple by our compatibility library, [@oasisprotocol/sapphire-paratime].
 
 There are compatibility layers in other languages, which may be found in [the repo].
@@ -101,7 +101,7 @@ There are compatibility layers in other languages, which may be found in [the re
 [@oasisprotocol/sapphire-paratime]: https://www.npmjs.com/package/@oasisprotocol/sapphire-paratime
 [the repo]: https://github.com/oasisprotocol/sapphire-paratime/tree/main/clients
 
-## Writing Secure dapps
+## Writing Secure dApps
 
 ### Wallets
 

--- a/docs/dapp/sapphire/quickstart.md
+++ b/docs/dapp/sapphire/quickstart.md
@@ -5,7 +5,7 @@
 </p>
 
 In this tutorial, you'll port an Eth project in under 10 minutes, and then go on
-to deploy a unique dapp that requires confidentiality to work.
+to deploy a unique dApp that requires confidentiality to work.
 By the end of the tutorial, you should feel comfortable setting up your Eth
 development environment to target Sapphire, and know how and when to use
 confidentiality.
@@ -233,7 +233,7 @@ index 0cd9d36..7db7cf8 100644
 This `wrap` function takes any kind of provider or signer you've got and turn
 it into one that works with Sapphire and confidentiality.
 For the most part, wrapping your signer/provider is the most you'll need to do
-to get your dapp running on Sapphire, but that's not a complete story since an
+to get your dApp running on Sapphire, but that's not a complete story since an
 unmodified contract may leak state through normal operation.
 
 And now for the moment we've all been waiting for:
@@ -265,14 +265,14 @@ something end-users need to think too much about.
 
 [@oasisprotocol/sapphire-paratime]: https://www.npmjs.com/package/@oasisprotocol/sapphire-paratime
 
-## Create a Sapphire-Native dapp
+## Create a Sapphire-Native dApp
 
 Porting an existing Eth app is cool, and can already provide benefits like
 protecting against MEV.
 However, starting from scratch with confidentiality in mind can unlock some
-really novel dapps and provide a [higher level of security].
+really novel dApps and provide a [higher level of security].
 
-One simple-but-useful dapp that takes advantage of confidentiality is a
+One simple-but-useful dApp that takes advantage of confidentiality is a
 [dead person's switch] that reveals a secret (let's say the encryption key to a
 data trove) if the operator fails to re-up before too long.
 Let's make it happen!
@@ -378,7 +378,7 @@ PRIVATE_KEY="0x..." pnpm hardhat run scripts/run-vigil.ts --network sapphire
 ```
 
 And if you see something like the following, you'll know you're well on the road
-to deploying confidential dapps on Sapphire.
+to deploying confidential dApps on Sapphire.
 
 ```
 Vigil deployed to: 0x74dC4879B152FDD1DDe834E9ba187b3e14f462f1

--- a/docs/general/manage-tokens/how-to-transfer-eth-erc20-to-emerald-paratime.md
+++ b/docs/general/manage-tokens/how-to-transfer-eth-erc20-to-emerald-paratime.md
@@ -6,7 +6,7 @@ the Wormhole token bridge.
 
 ## About
 
-[Emerald](/dapp/emerald/) is an Oasis ParaTime providing an Ethereum-compatible blockchain for the Oasis Network. If you want to use any dapp for DEX, NFT and similar built on Emerald, you will have to transfer your assets into the Emerald ParaTime.
+[Emerald](/dapp/emerald/) is an Oasis ParaTime providing an Ethereum-compatible blockchain for the Oasis Network. If you want to use any dApp for DEX, NFT and similar built on Emerald, you will have to transfer your assets into the Emerald ParaTime.
 
 To transfer your ROSE tokens into Emerald, follow [How to Transfer ROSE into a ParaTime](how-to-transfer-rose-into-paratime.mdx).
 
@@ -86,7 +86,7 @@ We suggest that you add the new contract address for wETH (your newly wrapped as
 
 ## Using Wrapped Assets on Oasis
 
-Now you can start using that wrapped assets across new Oasis dapps like the first DEX build on Emerald - [YuzuSwap](https://yuzu-swap.com), where you can swap, provide liquidity and farm YUZU rewards.
+Now you can start using that wrapped assets across new Oasis dApps like the first DEX build on Emerald - [YuzuSwap](https://yuzu-swap.com), where you can swap, provide liquidity and farm YUZU rewards.
 
 ![Start using wrapped assets on Oasis](../images/manage-tokens/wormhole/yuzuswap.png)
 

--- a/docs/general/oasis-network/faq.md
+++ b/docs/general/oasis-network/faq.md
@@ -25,7 +25,7 @@ Designed for the next generation of blockchain, the Oasis Network is the first p
 
 **Top-Tier Team:** The Oasis Team is made up of top talent from around the world with backgrounds from Apple, Google, Amazon, Goldman Sachs, UC Berkeley, Carnegie Mellon, Stanford, Harvard and more — all committed to growing and expanding the impact of the Oasis Network.
 
-### **Is the Oasis Protocol Foundation still taking grant applications for projects that are building new dapps?**
+### **Is the Oasis Protocol Foundation still taking grant applications for projects that are building new dApps?**
 
 Yes! We are still taking grant applications. You can apply any time [here](https://medium.com/oasis-protocol-project/oasis-foundation-grant-wishlist-3ad73b723d7).
 
@@ -68,7 +68,7 @@ Storage on the Oasis Network is determined by each ParaTime. There is a clear se
 
 ### **Does the Oasis Network have a vision for DeFi? Is it different from the mainstream view of DeFi?**
 
-The first generation of DeFi dapps has provided the market with a huge number of protocols and primitives that are meant to serve as the foundation for the specific components of a new financial system. Despite the current focus on short-term returns, we at Oasis believe the goal of DeFi applications should be to give rise to a new financial system that removes subjectivity, bias, and inefficiencies by leveraging programmable parameters instead of status, wealth, and geography. Oasis aims to support the next wave of DeFi applications by offering better privacy and scalability features than other Layer 1 networks.
+The first generation of DeFi dApps has provided the market with a huge number of protocols and primitives that are meant to serve as the foundation for the specific components of a new financial system. Despite the current focus on short-term returns, we at Oasis believe the goal of DeFi applications should be to give rise to a new financial system that removes subjectivity, bias, and inefficiencies by leveraging programmable parameters instead of status, wealth, and geography. Oasis aims to support the next wave of DeFi applications by offering better privacy and scalability features than other Layer 1 networks.
 
 ### **I’ve seen Oasis use both the terms “Open Finance” and “DeFi”? What’s the difference?**
 

--- a/docs/get-involved/delegation-policy.md
+++ b/docs/get-involved/delegation-policy.md
@@ -50,7 +50,7 @@ please reach out to the Oasis team as soon as possible.
 - Participate in community discussion on the network’s future roadmap.
 - Actively participate on the Oasis Network Community server on Discord
   and help answer questions from other community members.
-- Build or contribute to tools, services or dapps that benefit developers, node
+- Build or contribute to tools, services or dApps that benefit developers, node
   operators and/or the overall Oasis community.
 - Contribute code to Oasis projects.
 - Find and report issues related to any of the network protocols and/or their

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -98,7 +98,7 @@ const config = {
             position: 'left',
           },
           {
-            label: 'Create dapp',
+            label: 'Create dApp',
             to: '/dapp/',
             activeBaseRegex: '/dapp/',
             position: 'left',


### PR DESCRIPTION
After thorough discussion, we decided to use *dApp* term for denoting a distributed app. This PR replaces all *dapp* occurrences with *dApp*.