### PR TITLE
Migrate docs.oasis.dev -> docs.oasis.io

### DIFF
--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -28,6 +28,6 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./build
           force_orphan: true
-          cname: docs.oasis.dev
+          cname: docs.oasis.io
           user_name: github-actions[bot]
           user_email: 41898282+github-actions[bot]@users.noreply.github.com

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ![CI links status](https://github.com/oasisprotocol/docs/actions/workflows/ci-links.yml/badge.svg)
 ![Deployment status](https://github.com/oasisprotocol/docs/actions/workflows/deploy-main.yml/badge.svg)
 
-This repository contains Oasis Docs deployed at <https://docs.oasis.dev/>.
+This repository contains Oasis Docs deployed at <https://docs.oasis.io/>.
 
 They are built using [Docusaurus 2](https://docusaurus.io/), a modern static
 website generator.

--- a/docs/paratime/README.mdx
+++ b/docs/paratime/README.mdx
@@ -12,7 +12,7 @@ SDK].
     findSidebarItem('/paratime/minimal-runtime'),
     findSidebarItem('/paratime/modules'),
     findSidebarItem('/paratime/reproducibility'),
-    findSidebarItem('https://api.docs.oasis.dev/oasis-sdk/oasis_runtime_sdk'),
+    findSidebarItem('https://api.docs.oasis.io/oasis-sdk/oasis_runtime_sdk'),
 ]} />
 
 [Oasis Runtime SDK]:

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -11,7 +11,7 @@ const crossRepoLinksPlugin = require('./src/remark/cross-repo-links');
 const config = {
   title: 'Oasis Network Documentation',
   tagline: '',
-  url: process.env.URL ?? 'https://docs.oasis.dev',
+  url: process.env.URL ?? 'https://docs.oasis.io',
   baseUrl: '/',
   favicon: 'img/favicon.ico',
 

--- a/sidebarDapp.js
+++ b/sidebarDapp.js
@@ -41,7 +41,7 @@ const sidebars = {
         {
           type: 'link',
           label: 'Rust API',
-          href: 'https://api.docs.oasis.dev/oasis-sdk/oasis_contract_sdk',
+          href: 'https://api.docs.oasis.io/oasis-sdk/oasis_contract_sdk',
         },
         {
           type: 'link',

--- a/sidebarParatime.js
+++ b/sidebarParatime.js
@@ -11,7 +11,7 @@ const sidebars = {
     {
       type: 'link',
       label: 'Rust API',
-      href: 'https://api.docs.oasis.dev/oasis-sdk/oasis_runtime_sdk',
+      href: 'https://api.docs.oasis.io/oasis-sdk/oasis_runtime_sdk',
     },
   ],
 };


### PR DESCRIPTION
Migration plan after this PR is merged:
- [x] make sure docs.oasis.dev/* redirects to docs.oasis.io/* by either using another github pages with html redirects or a proxy which does http rewrite
- [x] migrate api.docs.oasis.io CNAME file
- merge external submodules migration PRs:
  - oasisprotocol/oasis-sdk#1117
  - oasisprotocol/oasis-core#4929
  - oasisprotocol/oasis-core-ledger#227
- [x] bump above submodules
