### PR TITLE
code-block-snippets: Move code block in place of paragraph

### DIFF
--- a/src/remark/code-block-snippets.js
+++ b/src/remark/code-block-snippets.js
@@ -8,9 +8,9 @@ const viewLinkUrl = require('../editUrl.js').viewLinkUrl;
 let mdFilePath = "";
 
 /**
- * Searches for ![code](source-file) pattern and replaces it with the code block containing the
- * content of the source-file. It also supports importing specific lines of code or regions
- * inside the source file defined by #region and #endregion literals.
+ * This plugin searches for ![code](source-file) pattern and replaces it with the code block
+ * containing the content of the source-file. It also supports importing specific lines of code or
+ * regions inside the source file defined by #region and #endregion literals.
  *
  * Examples:
  * ![code](../examples/my-example/shell-dump.txt)
@@ -19,26 +19,42 @@ let mdFilePath = "";
  * ![code go](../examples/my-example/src/server.go#L3)
  * ![code go](../examples/my-example/src/server.go#L5-L11 "src/server.go")
  * ![code go](../examples/my-example/src/account.go#native-account "Structure of the Native account")
+ */
+function plugin(options) {
+    function transform(tree) {
+        visit(tree, ['paragraph'], visitor);
+    }
+
+    return (root, vfile) => {
+        mdFilePath = vfile.history[0];
+        transform(root);
+    }
+}
+
+/**
+ * Find paragraph -> image pattern and perform the replacement.
  *
- * @typedef {import('mdast').Image} ImageNode
- * @typedef {import('mdast').Code} CodeNode
- * @param {Readonly<Omit<ImageNode, 'type'>> & CodeNode} node
+ * @param {Omit<import('mdast').Paragraph, 'type'> & import('mdast').Code} node
  */
 function visitor(node) {
-    if (!node.alt?.startsWith("code")) return;
+    if (!node.children || node.children.length != 1 || node.children[0].type != 'image' || !node.children[0]?.alt?.startsWith("code")) return;
+
+    // Move code block in place of the paragraph node.
+    const imgNode = node.children[0];
+    delete node.children;
 
     node.type = 'code';
 
     // Check for language as the second argument. e.g. ![code rust](some-file.rs)
-    node.lang = node.alt.split(" ")[1];
+    node.lang = imgNode.alt.split(" ")[1];
 
     // Use image title for the code block title.
-    if (node.title) {
-        node.meta = `title="${node.title}"`;
+    if (imgNode.title) {
+        node.meta = `title="${imgNode.title}"`;
     }
 
     // Source filename can have fragment symbol # followed by the line number(s) or region name.
-    const [relSrcFilePath, fragment] = node.url.split("#");
+    const [relSrcFilePath, fragment] = imgNode.url.split("#");
 
     // Resolve symlink (if any) and use that as the base for the source file path.
     // This is useful when the markdown file is in external submodule and so should be the source.
@@ -51,28 +67,28 @@ function visitor(node) {
     node.url = viewLinkUrl(srcFilePath);
 
     // Remove trailing newline, if any.
-    let snippet = code.replace(/\n$/, "")
+    let snippet = code.replace(/\n$/, "");
 
     // Check, if fragment matches line number or region name inside the file.
     if (fragment) {
         // From-to range of line numbers.
         let range;
-        const linesParts = /L(\d+)(-L(\d+))?/.exec(fragment)
+        const linesParts = /L(\d+)(-L(\d+))?/.exec(fragment);
         if (linesParts) {
             // Fragment contains either single line number (e.g. L14) or the range (e.g. L10-L23).
             range = [
                 parseInt(linesParts[1]),
                 parseInt(linesParts[3] ?? linesParts[1]),
-            ]
+            ];
         } else {
             // Fragment references region with #region and #endregion literals.
             range = [
                 code.split('\n').findIndex((line) => line.endsWith(`#region ${fragment}`)) + 2,
                 code.split('\n').findIndex((line) => line.endsWith(`#endregion ${fragment}`)),
-            ]
-            if (range[0] == 1) throw new ReferenceError(`"#region ${fragment}" not found`)
-            if (range[1] == -1) throw new ReferenceError(`"#endregion ${fragment}" not found`)
-            if (range[0] > range[1]) throw new ReferenceError(`"#region ${fragment}" appears after "#endregion ${fragment}"`)
+            ];
+            if (range[0] == 1) throw new ReferenceError(`"#region ${fragment}" not found`);
+            if (range[1] == -1) throw new ReferenceError(`"#endregion ${fragment}" not found`);
+            if (range[0] > range[1]) throw new ReferenceError(`"#region ${fragment}" appears after "#endregion ${fragment}"`);
         }
 
         // Append line numbers to source URL (even if region was initially provided).
@@ -88,17 +104,6 @@ function visitor(node) {
     }
 
     node.value = snippet;
-}
-
-function plugin(options) {
-    function transform(tree) {
-        visit(tree, ['image'], visitor);
-    }
-
-    return (root, vfile) => {
-        mdFilePath = vfile.history[0];
-        transform(root);
-    }
 }
 
 // Visitor also needs to be exported for running unit tests.

--- a/src/remark/code-block-snippets.test.js
+++ b/src/remark/code-block-snippets.test.js
@@ -9,11 +9,14 @@ const codeBlockSnippets = require('./code-block-snippets');
 // #endregion test-region
 
 test('basic', () => {
-    node = {
-        type: 'image',
-        alt: 'code js',
-        url: 'src/remark/code-block-snippets.test.js',
-        title: 'Some title',
+    let node = {
+        type: 'paragraph',
+        children: [{
+            type: 'image',
+            alt: 'code js',
+            url: 'src/remark/code-block-snippets.test.js',
+            title: 'Some title',
+        }],
     };
 
     codeBlockSnippets.visitor(node);
@@ -26,10 +29,13 @@ test('basic', () => {
 
 test('line-number', () => {
     let node = {
-        type: 'image',
-        alt: 'code js',
-        url: 'src/remark/code-block-snippets.test.js#L3',
-        title: 'Some title',
+        type: 'paragraph',
+        children: [{
+            type: 'image',
+            alt: 'code js',
+            url: 'src/remark/code-block-snippets.test.js#L3',
+            title: 'Some title',
+        }],
     };
 
     codeBlockSnippets.visitor(node);
@@ -42,10 +48,13 @@ test('line-number', () => {
 
 test('line-numbers', () => {
     let node = {
-        type: 'image',
-        alt: 'code js',
-        url: 'src/remark/code-block-snippets.test.js#L2-L4',
-        title: 'Some title',
+        type: 'paragraph',
+        children: [{
+            type: 'image',
+            alt: 'code js',
+            url: 'src/remark/code-block-snippets.test.js#L2-L4',
+            title: 'Some title',
+        }],
     };
 
     codeBlockSnippets.visitor(node);
@@ -58,10 +67,13 @@ test('line-numbers', () => {
 
 test('region', () => {
     let node = {
-        type: 'image',
-        alt: 'code js',
-        url: 'src/remark/code-block-snippets.test.js#test-region',
-        title: 'Some title',
+        type: 'paragraph',
+        children: [{
+            type: 'image',
+            alt: 'code js',
+            url: 'src/remark/code-block-snippets.test.js#test-region',
+            title: 'Some title',
+        }],
     };
 
     codeBlockSnippets.visitor(node);
@@ -75,10 +87,13 @@ test('region', () => {
 
 test('invalid-file', () => {
     let node = {
-        type: 'image',
-        alt: 'code js',
-        url: 'src/remark/foobar.js',
-        title: 'Some title',
+        type: 'paragraph',
+        children: [{
+            type: 'image',
+            alt: 'code js',
+            url: 'src/remark/foobar.js',
+            title: 'Some title',
+        }],
     };
 
     expect(() => {codeBlockSnippets.visitor(node)}).toThrow('ENOENT: no such file or directory, open \'src/remark/foobar.js\'');
@@ -86,10 +101,13 @@ test('invalid-file', () => {
 
 test('invalid-region', () => {
     let node = {
-        type: 'image',
-        alt: 'code js',
-        url: 'src/remark/code-block-snippets.test.js#some-nonexistent-region',
-        title: 'Some title',
+        type: 'paragraph',
+        children: [{
+            type: 'image',
+            alt: 'code js',
+            url: 'src/remark/code-block-snippets.test.js#some-nonexistent-region',
+            title: 'Some title',
+        }],
     };
 
     expect(() => {codeBlockSnippets.visitor(node)}).toThrow(ReferenceError);
@@ -97,11 +115,44 @@ test('invalid-region', () => {
 
 test('invalid-line-numbers', () => {
     let node = {
-        type: 'image',
-        alt: 'code js',
-        url: 'src/remark/code-block-snippets.test.js#L2-L400',
-        title: 'Some title',
+        type: 'paragraph',
+        children: [{
+            type: 'image',
+            alt: 'code js',
+            url: 'src/remark/code-block-snippets.test.js#L2-L400',
+            title: 'Some title',
+        }],
     };
 
     expect(() => {codeBlockSnippets.visitor(node)}).toThrow(ReferenceError);
+});
+
+test('code-in-separate-paragraph', () => {
+    let node = {
+        type: 'paragraph',
+        children: [{
+                type: 'image',
+                alt: 'code js',
+                url: 'src/remark/code-block-snippets.test.js',
+                title: 'Some title',
+        }],
+    };
+
+    const textNode = {
+        type: 'text',
+        value: 'some-text',
+    };
+
+    node.children.push(textNode);
+    codeBlockSnippets.visitor(node);
+    expect(node.type).toBe('paragraph');
+    node.children.pop();
+
+    node.children = [textNode, ...node.children];
+    codeBlockSnippets.visitor(node);
+    expect(node.type).toBe('paragraph');
+
+    node.children.push(textNode);
+    codeBlockSnippets.visitor(node);
+    expect(node.type).toBe('paragraph');
 });


### PR DESCRIPTION
Followup to #236 .

This PR fixes the level of the code block node (from `root -> paragraph -> code block` to `root -> code block`). Wrong code block level resulted in admonition anomalies in subsequent paragraphs.