### PR TITLE
Fixing swapped parameters (size and fill)

### DIFF
--- a/docs/dapp/sapphire/quickstart.mdx
+++ b/docs/dapp/sapphire/quickstart.mdx
@@ -312,7 +312,7 @@ index 414e974..49c95f9 100644
 +      chainId: 0x5aff,
 +      url: "https://testnet.sapphire.oasis.dev",
 +      accounts: [
-+        process.env.PRIVATE_KEY ?? Buffer.alloc(0, 32).toString("hex"),
++        process.env.PRIVATE_KEY ?? Buffer.alloc(32).toString("hex"),
 +      ],
 +    },
 +  },


### PR DESCRIPTION
The example configuration is using swapped parameters for `size` and `fill` in [`Buffer.alloc(...)`](https://nodejs.org/api/buffer.html#static-method-bufferallocsize-fill-encoding).

This causes the following error if no `PRIVATE_KEY` is set in `.env`:
```bash
$ yarn hardhat compile
Error HH8: There's one or more errors in your config file:

  * Invalid account: #0 for network: sapphire - private key too short, expected 32 bytes
  
To learn more about Hardhat's configuration, please go to https://hardhat.org/config/

For more info go to https://hardhat.org/HH8 or run Hardhat with --show-stack-traces
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```