### PR TITLE
Fix broken links and bump linkinator

### DIFF
--- a/docs/general/oasis-network/why-oasis.md
+++ b/docs/general/oasis-network/why-oasis.md
@@ -139,7 +139,7 @@ The Oasis Foundation has been working with many talented dev teams via our [Gran
 * [Dead Man’s Switch](https://medium.com/oasis-protocol-project/devaccelerator-spotlight-dead-mans-switch-32d07cdfc057): A decentralized, censorship-resistant tool for whistleblowers
 * [Luther.ai:](https://luther.ai)  Building artificial intelligence to Retain, Reinforce, Recall and ultimately augment your human memory.
 * [Oasis.Fish (by Stakefish)](https://oasis.fish/leaderboard/)
-* [Oasis Hubble (by Figment Networks)](https://hubble.figment.network/oasis/chains/amber)
+* [Oasis Hubble (by Figment Networks)](https://www.figment.io/hubble)
 * [Oasis Monitor (by Everstake)](https://oasismonitor.com)
 * [Oasisscan (by bitcat)](https://oasisscan.com)
 * [Oasis Smartstake (by Smartstake)](https://oasis.smartstake.io): Providing validation services for the Oasis Network

--- a/docs/node/run-your-node/advanced/sync-node-using-state-sync.md
+++ b/docs/node/run-your-node/advanced/sync-node-using-state-sync.md
@@ -1,6 +1,6 @@
 # Using State Sync for Quick Bootstraping
 
-The State Sync is a way to **quickly bootstrap** a **full Oasis node** (either a [validator node](../validator-node/README.md) or a [non-validator node](../non-validator-node.md)) by using [Tendermint's Light Client protocol](https://docs.tendermint.com/v0.35/tendermint-core/light-client.html). It allows one to initialize a node from a trusted height, its corresponding block's header and a trusted validator set (given in the [genesis document](../../genesis-doc.md)). It does so by securely updating the node's trusted state by requesting and verifying a minimal set of data from the network's full nodes.
+The State Sync is a way to **quickly bootstrap** a **full Oasis node** (either a [validator node](../validator-node/README.md) or a [non-validator node](../non-validator-node.md)) by using [Tendermint's Light Client protocol](https://docs.tendermint.com/main/tendermint-core/light-client.html). It allows one to initialize a node from a trusted height, its corresponding block's header and a trusted validator set (given in the [genesis document](../../genesis-doc.md)). It does so by securely updating the node's trusted state by requesting and verifying a minimal set of data from the network's full nodes.
 
 :::info
 
@@ -10,7 +10,7 @@ If you have access to an Oasis Node that is synced with the latest height, anoth
 
 :::caution
 
-Tendermint's Light Client protocol requires at least 1 full node to be correct to be able to [detect and submit evidence for a light client attack](https://docs.tendermint.com/v0.35/tendermint-core/light-client.html#security).
+Tendermint's Light Client protocol requires at least 1 full node to be correct to be able to [detect and submit evidence for a light client attack](https://docs.tendermint.com/main/tendermint-core/light-client.html#where-to-obtain-trusted-height-hash).
 
 :::
 

--- a/linkinator.config.json
+++ b/linkinator.config.json
@@ -1,7 +1,13 @@
 {
   "concurrency": 1,
   "recurse": true,
-  "skip": ["https://support.ledger.com/hc/en-us/articles/", "https://www.coinbase.com", "https://oasis.fish/leaderboard/"],
+  "skip": [
+    "oasis.fish",
+    "support.ledger.com",
+    "www.coinbase.com",
+    "www.coinspeaker.com",
+    "www.linkedin.com"
+  ],
   "verbosity": "error",
   "timeout": 0,
   "markdown": false,

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test": "jest src",
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
-    "blc": "linkinator http://localhost:3000/general",
+    "blc": "linkinator http://localhost:3000 --config linkinator.config.json",
     "lint-markdown": "markdownlint-cli2 'docs/**/*.md' 'docs/**/*.mdx'",
     "fmt-markdown": "markdownlint-cli2-fix 'docs/**/*.md' 'docs/**/*.mdx'"
   },
@@ -24,7 +24,7 @@
     "@easyops-cn/docusaurus-search-local": "^0.26.0",
     "@mdx-js/react": "^1.6.22",
     "clsx": "^1.1.1",
-    "linkinator": "^3.1.0",
+    "linkinator": "^4.1.0",
     "markdownlint-cli2": "^0.4.0",
     "plotly.js-basic-dist": "^2.12.1",
     "prism-react-renderer": "^1.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6022,11 +6022,6 @@ json5@^2.1.2, json5@^2.2.1:
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.1.tgz#655d50ed1e6f95ad1a3caababd2b0efda10b395c"
   integrity sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==
 
-jsonexport@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/jsonexport/-/jsonexport-3.2.0.tgz#e5b4905ea1f6c8f8e0f62e4ceb26e4a31f1c93a8"
-  integrity sha512-GbO9ugb0YTZatPd/hqCGR0FSwbr82H6OzG04yzdrG7XOe4QZ0jhQ+kOsB29zqkzoYJLmLxbbrFiuwbQu891XnQ==
-
 jsonfile@^6.0.1:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-6.1.0.tgz#bc55b2634793c679ec6403094eb13698a6ec0aae"
@@ -6094,22 +6089,21 @@ linkify-it@^3.0.1:
   dependencies:
     uc.micro "^1.0.1"
 
-linkinator@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/linkinator/-/linkinator-3.1.0.tgz#403999203d61acfcc592c3f7fd60332bdce4f423"
-  integrity sha512-ikQtLZ0JtY2JQXGZlzHID9Y87R4Zxe4TPAtFTem9T2UxQqXr0Ab8z9fse+apHEaD2l+WIX8f/P0IMODBMHhPWw==
+linkinator@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/linkinator/-/linkinator-4.1.0.tgz#c14dc55d421dbb143ded674e1bd0220bb1a80afd"
+  integrity sha512-TfTn2zJXNXBKd815aDoqSFbUnOlvhw5ZkvJ3LzbSOkzcYsamoJg+9wLTtqQfkeAJ/kTsosiNf8nzTpySx1DZPA==
   dependencies:
     chalk "^5.0.0"
     escape-html "^1.0.3"
     gaxios "^5.0.0"
     glob "^8.0.1"
     htmlparser2 "^8.0.1"
-    jsonexport "^3.2.0"
     marked "^4.0.3"
     meow "^10.1.1"
     mime "^3.0.0"
     server-destroy "^1.0.1"
-    update-notifier "^5.1.0"
+    srcset "^5.0.0"
 
 loader-runner@^4.2.0:
   version "4.3.0"
@@ -8285,6 +8279,11 @@ sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==
+
+srcset@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/srcset/-/srcset-5.0.0.tgz#9df6c3961b5b44a02532ce6ae4544832609e2e3f"
+  integrity sha512-SqEZaAEhe0A6ETEa9O1IhSPC7MdvehZtCnTR0AftXk3QhY2UNgb+NApFOUPZILXk/YTDfFxMTNJOBpzrJsEdIA==
 
 stable@^0.1.8:
   version "0.1.8"


### PR DESCRIPTION
- fixes broken link to figment.network (-> figment.io)
- fixes broken link to tendermint (/v0.35/ -> /main/)
- fixes root crawling URL for linkinator which missed some links (/general -> /)
- simplifies linkinator config
- bumps linkinator to 4.1.0
- bumps external/oasis-core submodule