### PR TITLE
CSS: Add bright background to images when using dark theme

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -89,3 +89,8 @@ html[data-theme='dark'] .docusaurus-highlight-code-line {
 .theme-doc-sidebar-menu {
   font-size: 14px;
 }
+
+/* Hack to make .svg and .png diagrams readable in dark theme */
+html[data-theme='dark'] main img {
+  background-color: #fff;
+}


### PR DESCRIPTION
A temporary hack to mitigate #308. Adds white background to images when switching to dark theme. 

| before | after |
|------------|--------|
| ![image](https://user-images.githubusercontent.com/83672/202437001-1cf28478-fd38-45a5-b729-145b51abce6b.png) | ![image](https://user-images.githubusercontent.com/83672/202437067-6e21265d-426c-4568-bcb9-64ef7e480275.png) |
| ![image](https://user-images.githubusercontent.com/83672/202437229-2c259a62-ae93-4619-b135-9e3942d8c05e.png) |  ![image](https://user-images.githubusercontent.com/83672/202437179-4bdfdbbc-75f5-4b91-8479-a2b6323efbe6.png) |