### PR TITLE
docs/node: Add estimate of allowed TEE clock difference

### DIFF
--- a/docs/node/run-your-node/prerequisites/set-up-trusted-execution-environment-tee.md
+++ b/docs/node/run-your-node/prerequisites/set-up-trusted-execution-environment-tee.md
@@ -17,8 +17,8 @@ additional driver and software components are properly installed and running.
 ## Ensure Clock Synchronization
 
 Due to additional sanity checks within runtime enclaves, you should ensure that
-the node's local clock is synchronized (e.g. using NTP). Otherwise you may
-experience unexpected runtime aborts.
+the node's local clock is synchronized (e.g. using NTP). If it is off by more
+than half a second you may experience unexpected runtime aborts.
 
 ## Install SGX Linux Driver
 


### PR DESCRIPTION
Add concrete estimate of allowed TEE clock difference to emphasize the importance of an NTP daemon.

If the system clock is behind by 0.5s a Testnet Cipher node still works, if it is by more than 1s it is currently aborting with:
```
{"caller":"trust.go:43","level":"info","module":"worker/executor/committee","msg":"asking the runtime to perform light client sync","runtime_id":"0000000000000000000000000000000000000000000000000000000000000000","ts":"2022-12-04T19:24:00.7919611Z"}
{"level":"warn","module":"runtime","msg":"thread 'main' panicked at 'runtime execution failed: Enclave panicked.', runtime-loader/bin/main.rs:57:10","runtime_id":"0000000000000000000000000000000000000000000000000000000000000000","runtime_name":"cipher-paratime","ts":"2022-12-04T19:24:00.839944244Z"}
```
Next version will report this issue with: `clock appeared to have ran backwards`.