### PR TITLE
docs/node: Increase minimal memory requirements for Mainnet consensus

### DIFF
--- a/docs/node/run-your-node/prerequisites/hardware-recommendations.md
+++ b/docs/node/run-your-node/prerequisites/hardware-recommendations.md
@@ -76,7 +76,7 @@ that use a Trusted Execution Environment (TEE).
 ### Memory
 
 * Consensus validator or non-validator node:
-  * Minimum: 4 GB of ECC RAM
+  * Minimum: 6 GB of ECC RAM
   * Recommended: 8 GB of ECC RAM
 
 * All ParaTime compute or client nodes:


### PR DESCRIPTION
It seems the minimal requirements during Badgerdb compaction on a full node on Mainnet have increased a bit. Measurement spiked at 5.3 GB.