### PR TITLE
dapp: Remove redundant ParaTime terms from MetaMask network name

### DIFF
--- a/docs/dapp/emerald/README.mdx
+++ b/docs/dapp/emerald/README.mdx
@@ -50,7 +50,7 @@ To get started building on our Emerald ParaTime, you can use our public Web3 gat
       params: [
         {
           chainId: '0xa516',
-          chainName: 'Emerald Paratime Mainnet',
+          chainName: 'Oasis Emerald',
           nativeCurrency: {
             name: 'Emerald Rose',
             symbol: 'ROSE',
@@ -86,7 +86,7 @@ To get started building on our Emerald ParaTime, you can use our public Web3 gat
       params: [
         {
           chainId: '0xa515',
-          chainName: 'Emerald Paratime Testnet',
+          chainName: 'Oasis Emerald Testnet',
           nativeCurrency: {
             name: 'TEST',
             symbol: 'TEST',

--- a/docs/dapp/sapphire/README.mdx
+++ b/docs/dapp/sapphire/README.mdx
@@ -46,7 +46,7 @@ gateway, fully compatible with Ethereum's Web3 gateway.
       params: [
         {
           chainId: '0x5afe',
-          chainName: 'Sapphire ParaTime Mainnet',
+          chainName: 'Oasis Sapphire',
           nativeCurrency: {
             name: 'ROSE',
             symbol: 'ROSE',
@@ -82,7 +82,7 @@ gateway, fully compatible with Ethereum's Web3 gateway.
       params: [
         {
           chainId: '0x5aff',
-          chainName: 'Sapphire ParaTime Testnet',
+          chainName: 'Oasis Sapphire Testnet',
           nativeCurrency: {
             name: 'TEST',
             symbol: 'TEST',


### PR DESCRIPTION
Following the new branding guidelines this PR changes the default label for Emerald and Sapphire networks in MetaMask:
- Emerald ParaTime Mainnet -> Oasis Emerald
- Emerald ParaTime Testnet -> Oasis Emerald Testnet
- Sapphire ParaTime Mainnet -> Oasis Sapphire
- Sapphire ParaTime Testnet -> Oasis Sapphire Testnet

Related PR https://github.com/ethereum-lists/chains/pull/2147