### PR TITLE
docs: Add known wROSE address for Sapphire

### DIFF
--- a/docs/dapp/sapphire/addresses.md
+++ b/docs/dapp/sapphire/addresses.md
@@ -1,0 +1,13 @@
+---
+description: List of Standard Contract Addresses
+---
+
+# Standard Contract Addresses
+
+| Name         | Mainnet Address                            | Testnet Address                            | Verify                                                           | Source                          |
+|--------------|--------------------------------------------|--------------------------------------------|------------------------------------------------------------------|---------------------------------|
+| Wrapped ROSE | `8Bc2B030b299964eEfb5e1e0b36991352E56D2D3` | `B759a0fbc1dA517aF257D5Cf039aB4D86dFB3b94` | [Mainnet][wrose-verify-mainnet], [Testnet][wrose-verify-testnet] | [WrappedROSE.sol][wrose-source] |
+
+[wrose-source]: https://github.com/oasisprotocol/sapphire-paratime/blob/main/contracts/contracts/WrappedROSE.sol
+[wrose-verify-mainnet]: https://sourcify.dev/#/lookup/0x8Bc2B030b299964eEfb5e1e0b36991352E56D2D3
+[wrose-verify-testnet]: https://sourcify.dev/#/lookup/0xB759a0fbc1dA517aF257D5Cf039aB4D86dFB3b94

--- a/sidebarDapp.js
+++ b/sidebarDapp.js
@@ -28,6 +28,7 @@ const sidebars = {
         'dapp/sapphire/guide',
         'dapp/sapphire/browser',
         'dapp/sapphire/precompiles',
+        'dapp/sapphire/addresses',
       ],
     },
     {


### PR DESCRIPTION
Adds "Standard Contract Addresses" section at the end of  Precompiles chapter.

Preview: https://deploy-preview-389--trusting-archimedes-14c863.netlify.app/dapp/sapphire/addresses