### PR TITLE
Update discord link in the footer

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -141,7 +141,7 @@ const config = {
             items: [
               {
                 label: 'Discord',
-                href: 'https://discord.gg/pJdWeVtmHT',
+                href: 'https://discord.gg/oasisprotocol',
               },
             ],
           },


### PR DESCRIPTION
Missed in https://github.com/oasisprotocol/docs/pull/428