### PR TITLE
dApps > Sapphire > Quickstart - Restrict hardhat version to 2.12.x

### DIFF
--- a/docs/dapp/sapphire/quickstart.mdx
+++ b/docs/dapp/sapphire/quickstart.mdx
@@ -289,7 +289,7 @@ Let's make it happen!
 We're going to use Hardhat this time because it's very convenient to use.
 
 1. Make & enter a new directory
-2. `npx hardhat` then create a TypeScript project.
+2. `npx hardhat@~2.12.0` then create a TypeScript project.
 3. Add [`@oasisprotocol/sapphire-hardhat`] as dependency:
 
   ```sh


### PR DESCRIPTION
The package `@oasisprotocol/sapphire-hardhat` has been designed for hardhat 2.12.x. Following the docs exactly as written results in a non-functional `run-vigil.ts` in the end, since `npx hardhat` downloads the latest hardhat version, which is 2.16.0 at the time of writing this.

This pull request specifies the version of hardhat to initialize so following the instructions works as intended.