### PR TITLE
docs: Reorganize landing page to expose Sapphire and OPL

### DIFF
--- a/docs/README.mdx
+++ b/docs/README.mdx
@@ -1,3 +1,4 @@
+import DocCard from '@theme/DocCard';
 import DocCardList from '@theme/DocCardList';
 import {findSidebarItem} from '@site/src/sidebarUtils';
 
@@ -5,13 +6,39 @@ import {findSidebarItem} from '@site/src/sidebarUtils';
 
 ## Use Oasis
 
-These guides provide general overview of the Oasis Network and introduce basic
-tools for you to get started.
+The introductory section contains general overview of the Oasis Network such as
+the distinction between the consensus layer and different ParaTimes. It
+also covers wallets and other tools for managing your assets across the Oasis
+chains and how to use unique Oasis features.
 
 <DocCardList items={[
     findSidebarItem('/general/oasis-network/'),
     findSidebarItem('/general/manage-tokens/'),
 ]} />
+
+## Create dApp
+
+Contains learning material for the smart contract developers. Since the Oasis
+platform is best known for confidentiality, the most notable ParaTime is
+[Oasis Sapphire], an **EVM-compatible** ParaTime with **built-in contract state
+encryption**. The Oasis team also prepared a set of libraries called the
+[Oasis Privacy Layer] to **bridge existing dApps running on other chains** to
+use the unique Sapphire's confidentiality.
+
+The section also covers other ParaTimes such as the non-confidential
+[Oasis Emerald] and Wasm-compatible, confidential [Oasis Cipher].
+
+<DocCardList items={[
+    findSidebarItem('/dapp/sapphire/'),
+    findSidebarItem('/dapp/opl/'),
+    findSidebarItem('/dapp/emerald/'),
+    findSidebarItem('/dapp/cipher/'),
+]} />
+
+[Oasis Sapphire]: dapp/sapphire/README.mdx
+[Oasis Privacy Layer]: dapp/opl/README.md
+[Oasis Emerald]: dapp/emerald/README.mdx
+[Oasis Cipher]: dapp/emerald/README.mdx
 
 ## Get Involved
 
@@ -25,7 +52,7 @@ developers and how to contribute to the network.
     findSidebarItem('/get-involved/oasis-core'),
 ]} />
 
-## Run your own Node
+## Run Node
 
 If you want to run your own Oasis node, the following section will provide you
 with guides on the current Mainnet and Testnet network parameters and how to
@@ -40,28 +67,24 @@ queries on the network.
     findSidebarItem('/node/run-your-node'),
 ]} />
 
-## DApps and ParaTime Developers
+## Build ParaTimes
 
-These two sections are focused on developers building applications on top of
-the Oasis Network. Smart contract developers will be interested in the
-EVM-compatible Emerald and confidential Sapphire ParaTimes. For maximum
-security and confidentiality, the Oasis team designed a novel Cipher ParaTime
-executing Wasm smart contracts and which allows you to develop smart contracts
-in Rust using the Oasis Contract SDK. Finally, developers can learn how to
-build their own ParaTime running on the Oasis Network.
+Apart from Emerald, Cipher, Sapphire and the Key manager ParaTimes, developers
+can learn how to write, compile, sign and deploy their own ParaTimes on the
+Oasis Network.
 
-<DocCardList items={[
-    findSidebarItem('/dapp/emerald/'),
-    findSidebarItem('/dapp/sapphire/'),
-    findSidebarItem('/dapp/cipher/'),
-    findSidebarItem('/paratime/'),
-]} />
+<DocCard item={findSidebarItem('/paratime/')} />
 
-## Oasis Core Contributors
+## Develop Core
 
 Whether you want to contribute your code to the core components of the Oasis
 Network or just learn more about the Oasis core, this is the place for you.
 
-<DocCardList items={[
-    findSidebarItem('/core/'),
-]} />
+<DocCard item={ findSidebarItem('/core/') } />
+
+Development of interoperable Oasis network components are made by consensus.
+Similar to the Ethereum's ERC/EIP mechanism, Oasis follows Architectural
+Decision Records (ADRs) which are first proposed, voted on and can then be
+implemented, if accepted.
+
+<DocCard item={ findSidebarItem('/adrs') } />

--- a/docs/dapp/README.mdx
+++ b/docs/dapp/README.mdx
@@ -6,7 +6,7 @@ import DocCard from '@theme/DocCard';
 import DocCardList from '@theme/DocCardList';
 import {findSidebarItem} from '@site/src/sidebarUtils';
 
-# Overview
+# Create dApp
 
 ![Oasis architectural design including ParaTime and consensus layers](../general/images/architecture/technology_scalability.svg)
 

--- a/docs/general/README.mdx
+++ b/docs/general/README.mdx
@@ -1,7 +1,7 @@
 import DocCardList from '@theme/DocCardList';
 import {findSidebarItem} from '@site/src/sidebarUtils';
 
-# Overview
+# Use Oasis
 
 This chapter provides general overview of the Oasis Network and introduces
 basic tools for you to get started.

--- a/docs/general/oasis-network/README.mdx
+++ b/docs/general/oasis-network/README.mdx
@@ -1,7 +1,7 @@
 import DocCard from '@theme/DocCard';
 import {findSidebarItem} from '@site/src/sidebarUtils';
 
-# Overview of the Oasis Network
+# Oasis Network
 
 The Oasis Network is a Layer 1 decentralized blockchain network designed to be uniquely scalable, privacy-first and versatile.
 

--- a/docs/node/README.mdx
+++ b/docs/node/README.mdx
@@ -1,7 +1,7 @@
 import DocCardList from '@theme/DocCardList';
 import {findSidebarItem} from '@site/src/sidebarUtils';
 
-# Overview
+# Run Node
 
 The following documentation is intended to assist any individual or
 organization in participating in the Oasis network as a node operator. To join
@@ -37,7 +37,7 @@ If you have any questions about running a node you can find us on [Discord].
 [Oasis Scan]: https://www.oasisscan.com/validators
 [Discord]: https://oasis.io/discord
 
-## Set Up Your Node overview
+## Node Roles
 
 To run a **Validator node**, make sure your system meets the [Hardware] and the
 [System] prerequisites and has [Oasis Node] installed.
@@ -53,10 +53,12 @@ To run a **ParaTime node** make sure to first set up a Validator node. Then,
 set up a [trusted execution environment (TEE)], if you want to run confidential
 ParaTimes. After that, proceed to the [Run a ParaTime node].
 
-Finally, if you are building a service on top of the Oasis Network, we suggest
-that you set up your own **[Non-validator node]** and (optionally) a
-**[ParaTime client node]**, so that your service do not depend on any third
-party endpoints which are often behind a traffic limiter.
+If you are **building a service** on top of the Oasis Network, you will simply
+want to set up your own **[Non-validator node]** and (optionally) a
+**[ParaTime client node]**. This way, your service will not depend on third
+party endpoints which can be behind a traffic limiter, can go down unexpectedly,
+or they can have some more CPU-intensive queries disabled which you would like
+to use.
 
 [Hardware]: ./run-your-node/prerequisites/hardware-recommendations.md
 [System]: ./run-your-node/prerequisites/system-configuration.mdx
@@ -70,7 +72,8 @@ party endpoints which are often behind a traffic limiter.
 ## Quick Navigation
 
 <DocCardList items={[
-    findSidebarItem('/node/mainnet/upgrade-log'),
+    findSidebarItem('/node/mainnet/'),
+    findSidebarItem('/node/testnet/'),
     findSidebarItem('/node/run-your-node/prerequisites'),
     findSidebarItem('/node/run-your-node/validator-node/'),
     findSidebarItem('/node/run-your-node/non-validator-node'),

--- a/docs/paratime/README.mdx
+++ b/docs/paratime/README.mdx
@@ -1,7 +1,11 @@
+---
+description: Build your own ParaTime using Oasis Runtime SDK
+---
+
 import DocCardList from '@theme/DocCardList';
 import {findSidebarItem} from '@site/src/sidebarUtils';
 
-# Overview
+# Build ParaTime
 
 This chapter will teach you how to build your own ParaTime with [Oasis Runtime
 SDK].

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -10,7 +10,7 @@ const codeBlockSnippetsPlugin = require('./src/remark/code-block-snippets').plug
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
-  title: 'Oasis Network Documentation',
+  title: 'Oasis Documentation',
   tagline: '',
   url: process.env.URL ?? 'https://docs.oasis.io',
   baseUrl: '/',
@@ -88,6 +88,12 @@ const config = {
             position: 'left',
           },
           {
+            label: 'Create dApp',
+            to: '/dapp/',
+            activeBaseRegex: '/dapp/',
+            position: 'left',
+          },
+          {
             label: 'Get Involved',
             to: '/get-involved/',
             position: 'left',
@@ -97,12 +103,6 @@ const config = {
             label: 'Run Node',
             to: '/node/',
             activeBaseRegex: '/node/',
-            position: 'left',
-          },
-          {
-            label: 'Create dApp',
-            to: '/dapp/',
-            activeBaseRegex: '/dapp/',
             position: 'left',
           },
           {

--- a/sidebarDapp.js
+++ b/sidebarDapp.js
@@ -3,7 +3,11 @@
 /** @type {import('@docusaurus/plugin-content-docs').SidebarsConfig} */
 const sidebars = {
   developers: [
-    'dapp/README',
+    {
+      type: 'doc',
+      label: 'Overview',
+      id: 'dapp/README',
+    },
     {
       type: 'category',
       label: 'Sapphire',

--- a/sidebarGeneral.js
+++ b/sidebarGeneral.js
@@ -3,7 +3,11 @@
 /** @type {import('@docusaurus/plugin-content-docs').SidebarsConfig} */
 const sidebars = {
   general: [
-    'general/README',
+    {
+      type: 'doc',
+      label: 'Overview',
+      id: 'general/README',
+    },
     {
       type: 'category',
       label: 'Oasis Network',

--- a/sidebarNode.js
+++ b/sidebarNode.js
@@ -3,7 +3,11 @@
 /** @type {import('@docusaurus/plugin-content-docs').SidebarsConfig} */
 const sidebars = {
   operators: [
-    'node/README',
+    {
+      type: 'doc',
+      label: 'Overview',
+      id: 'node/README',
+    },
     {
       type: 'category',
       label: 'Mainnet',

--- a/sidebarParatime.js
+++ b/sidebarParatime.js
@@ -3,7 +3,11 @@
 /** @type {import('@docusaurus/plugin-content-docs').SidebarsConfig} */
 const sidebars = {
   paratime: [
-    'paratime/README',
+    {
+      type: 'doc',
+      label: 'Overview',
+      id: 'paratime/README',
+    },
     'paratime/prerequisites',
     'paratime/minimal-runtime',
     'paratime/modules',


### PR DESCRIPTION
- Moves "Create dApp" right after the "Use Oasis" in the top toolbar
- Revamps the landing page to include Oasis Sapphire at the top (right after the general info) followed by OPL.
- Replaces "Overview" chapter title with concrete "Use Oasis", "Create dApp", "Run Node" or "Build ParaTime" since this reflects the window/tab title and should be unique. The "Overview" toolbar label in the sidebar is still shown.
- Bumps ADRs repo to also include the new ADR 21 and 22.
- Website's general "Oasis Network Documentation" title is now just "Oasis Documentation"
- Some Run Node chapter cosmetic fixes