### PR TITLE
sapphire/addresses: add Multicall V3 official mainnet deployment

### DIFF
--- a/docs/dapp/sapphire/addresses.md
+++ b/docs/dapp/sapphire/addresses.md
@@ -6,8 +6,13 @@ description: List of Standard Contract Addresses
 
 | Name         | Mainnet Address                            | Testnet Address                            | Verify                                                           | Source                          |
 |--------------|--------------------------------------------|--------------------------------------------|------------------------------------------------------------------|---------------------------------|
-| Wrapped ROSE | `8Bc2B030b299964eEfb5e1e0b36991352E56D2D3` | `B759a0fbc1dA517aF257D5Cf039aB4D86dFB3b94` | [Mainnet][wrose-verify-mainnet], [Testnet][wrose-verify-testnet] | [WrappedROSE.sol][wrose-source] |
+| Wrapped ROSE | `0x8Bc2B030b299964eEfb5e1e0b36991352E56D2D3` | `0xB759a0fbc1dA517aF257D5Cf039aB4D86dFB3b94` | [Mainnet][wrose-verify-mainnet], [Testnet][wrose-verify-testnet] | [WrappedROSE.sol][wrose-source] |
+| [Multicall V3][multicall] | `0xcA11bde05977b3631167028862bE2a173976CA11` | - | [Mainnet][multicall-verify-mainnet] | [Multicall3.sol][multicall-source] |
 
 [wrose-source]: https://github.com/oasisprotocol/sapphire-paratime/blob/main/contracts/contracts/WrappedROSE.sol
 [wrose-verify-mainnet]: https://sourcify.dev/#/lookup/0x8Bc2B030b299964eEfb5e1e0b36991352E56D2D3
 [wrose-verify-testnet]: https://sourcify.dev/#/lookup/0xB759a0fbc1dA517aF257D5Cf039aB4D86dFB3b94
+
+[multicall-source]: https://github.com/mds1/multicall/blob/main/src/Multicall3.sol
+[multicall-verify-mainnet]: https://explorer.sapphire.oasis.io/address/0xcA11bde05977b3631167028862bE2a173976CA11/contracts
+[multicall]: https://github.com/mds1/multicall

--- a/docs/dapp/sapphire/addresses.md
+++ b/docs/dapp/sapphire/addresses.md
@@ -6,13 +6,13 @@ description: List of Standard Contract Addresses
 
 | Name         | Mainnet Address                            | Testnet Address                            | Verify                                                           | Source                          |
 |--------------|--------------------------------------------|--------------------------------------------|------------------------------------------------------------------|---------------------------------|
-| Wrapped ROSE | `0x8Bc2B030b299964eEfb5e1e0b36991352E56D2D3` | `0xB759a0fbc1dA517aF257D5Cf039aB4D86dFB3b94` | [Mainnet][wrose-verify-mainnet], [Testnet][wrose-verify-testnet] | [WrappedROSE.sol][wrose-source] |
 | [Multicall V3][multicall] | `0xcA11bde05977b3631167028862bE2a173976CA11` | - | [Mainnet][multicall-verify-mainnet] | [Multicall3.sol][multicall-source] |
+| Wrapped ROSE | `0x8Bc2B030b299964eEfb5e1e0b36991352E56D2D3` | `0xB759a0fbc1dA517aF257D5Cf039aB4D86dFB3b94` | [Mainnet][wrose-verify-mainnet], [Testnet][wrose-verify-testnet] | [WrappedROSE.sol][wrose-source] |
+
+[multicall-source]: https://github.com/mds1/multicall/blob/main/src/Multicall3.sol
+[multicall-verify-mainnet]: https://sourcify.dev/#/lookup/0xcA11bde05977b3631167028862bE2a173976CA11
+[multicall]: https://multicall3.com/
 
 [wrose-source]: https://github.com/oasisprotocol/sapphire-paratime/blob/main/contracts/contracts/WrappedROSE.sol
 [wrose-verify-mainnet]: https://sourcify.dev/#/lookup/0x8Bc2B030b299964eEfb5e1e0b36991352E56D2D3
 [wrose-verify-testnet]: https://sourcify.dev/#/lookup/0xB759a0fbc1dA517aF257D5Cf039aB4D86dFB3b94
-
-[multicall-source]: https://github.com/mds1/multicall/blob/main/src/Multicall3.sol
-[multicall-verify-mainnet]: https://explorer.sapphire.oasis.io/address/0xcA11bde05977b3631167028862bE2a173976CA11/contracts
-[multicall]: https://github.com/mds1/multicall


### PR DESCRIPTION
As per https://github.com/mds1/multicall/issues/144 the Multicall V3 contracts are deployed on the same address and is now listed on https://www.multicall3.com/