### PR TITLE
bump rosetta gateway version recommendations

### DIFF
--- a/docs/node/mainnet/README.md
+++ b/docs/node/mainnet/README.md
@@ -25,7 +25,7 @@ Feel free to use other seed nodes besides the one provided here.
 * [Oasis Core](https://github.com/oasisprotocol/oasis-core) version:
   * [22.2.9](https://github.com/oasisprotocol/oasis-core/releases/tag/v22.2.9)
 * [Oasis Rosetta Gateway](https://github.com/oasisprotocol/oasis-rosetta-gateway) version:
-  * [2.3.0](https://github.com/oasisprotocol/oasis-rosetta-gateway/releases/tag/v2.3.0)
+  * [2.4.0](https://github.com/oasisprotocol/oasis-rosetta-gateway/releases/tag/v2.4.0)
 
 :::info
 

--- a/docs/node/testnet/README.md
+++ b/docs/node/testnet/README.md
@@ -43,7 +43,7 @@ Feel free to use other seed nodes besides the one provided here.
     ([read more][handling network upgrades]):
     * [22.0.3](https://github.com/oasisprotocol/oasis-core/releases/tag/v22.0.3) (until epoch **15056**)
 * [Oasis Rosetta Gateway](https://github.com/oasisprotocol/oasis-rosetta-gateway) version:
-  * [2.3.0](https://github.com/oasisprotocol/oasis-rosetta-gateway/releases/tag/v2.3.0)
+  * [2.5.0](https://github.com/oasisprotocol/oasis-rosetta-gateway/releases/tag/v2.5.0)
 
 :::info
 


### PR DESCRIPTION
We released 2.4.0 a bit ago with the oasis-core version for mainnet. Should update this.

For testnet, 2.5.0 is out with oasis-core 22.2.11.