### PR TITLE
docs: Use part, chapter and section consistently

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,20 +86,22 @@ link checker in `package.json`._
 ### Documentation structure
 
 `docs` folder contains markdown files of the documentation. Each subfolder
-represents one of the top-level chapter (general, node, dApp, paratime, core
-etc.).
+represents a documentation **part** (general, node, dApp, paratime, core etc.).
+Each markdown file inside a part corresponds to a **chapter** (subchapter for a
+markdown file inside a subfolder) and each subtitle of a chapter is called a
+**section** (subsection etc.).
 
-Some top-level chapter may contain markdown files or folders hosted and
-maintained in other Oasis repositories (e.g. oasis-sdk, oasis-core). In this
-case, a complete git submodule for the repository is cloned inside `external`
-folder. Then, symbolic links to specific markdown files or folders are added
-inside `docs` accordingly.
+Some parts may contain markdown files or folders hosted and maintained in other
+Oasis repositories (e.g. oasis-sdk, oasis-core). In this case, a complete git
+submodule for the repository is cloned inside `external` folder. Then, symbolic
+links to specific markdown files or folders are added inside `docs`
+accordingly.
 
 While all markdown files inside `docs` are compiled, not all files may be
 reachable via sidebars directly. Each top-level chapter defines own
 sidebar structure inside their `sidebarChapterName.js` file.
 
-Nouns, adjectives and verbs in section titles should be capitalized.
+Nouns, adjectives and verbs in the titles should be capitalized.
 
 ### index.md, README.md, overview.md
 

--- a/docs/README.mdx
+++ b/docs/README.mdx
@@ -6,7 +6,7 @@ import {findSidebarItem} from '@site/src/sidebarUtils';
 
 ## Use Oasis
 
-The introductory section contains general overview of the Oasis Network such as
+This introductory part contains general overview of the Oasis Network such as
 the distinction between the consensus layer and different ParaTimes. It
 also covers wallets and other tools for managing your assets across the Oasis
 chains and how to use unique Oasis features.
@@ -14,6 +14,7 @@ chains and how to use unique Oasis features.
 <DocCardList items={[
     findSidebarItem('/general/oasis-network/'),
     findSidebarItem('/general/manage-tokens/'),
+    findSidebarItem('/general/manage-tokens/cli/'),
 ]} />
 
 ## Create dApp
@@ -25,7 +26,7 @@ encryption**. The Oasis team also prepared a set of libraries called the
 [Oasis Privacy Layer] to **bridge existing dApps running on other chains** to
 use the unique Sapphire's confidentiality.
 
-The section also covers other ParaTimes such as the non-confidential
+The part also covers other ParaTimes such as the non-confidential
 [Oasis Emerald] and Wasm-compatible, confidential [Oasis Cipher].
 
 <DocCardList items={[
@@ -54,7 +55,7 @@ developers and how to contribute to the network.
 
 ## Run Node
 
-If you want to run your own Oasis node, the following section will provide you
+If you want to run your own Oasis node, this part will provide you
 with guides on the current Mainnet and Testnet network parameters and how to
 set up your node, let it be a validator node, perhaps running a ParaTime or
 just a simple client node for your server to submit transactions and perform
@@ -69,22 +70,23 @@ queries on the network.
 
 ## Build ParaTimes
 
-Apart from Emerald, Cipher, Sapphire and the Key manager ParaTimes, developers
-can learn how to write, compile, sign and deploy their own ParaTimes on the
-Oasis Network.
+Apart from the Sapphire, Emerald, Cipher and the Key manager ParaTimes,
+you can also write, compile, sign and deploy your own ParaTime on the Oasis
+Network. This part describes the knobs you need to use to do so.
 
 <DocCard item={findSidebarItem('/paratime/')} />
 
 ## Develop Core
 
 Whether you want to contribute your code to the core components of the Oasis
-Network or just learn more about the Oasis core, this is the place for you.
+Network or just learn more about the Oasis consensus layer and other core
+components, this is the part for you.
 
 <DocCard item={ findSidebarItem('/core/') } />
 
-Development of interoperable Oasis network components are made by consensus.
-Similar to the Ethereum's ERC/EIP mechanism, Oasis follows Architectural
-Decision Records (ADRs) which are first proposed, voted on and can then be
-implemented, if accepted.
+Additions or changes to the interoperable Oasis network components are always
+made with consensus. Similar to the Ethereum's ERC/EIP mechanism Oasis follows
+formal Architectural Decision Records (ADRs) which are first proposed, voted on
+and finally implemented, if accepted.
 
 <DocCard item={ findSidebarItem('/adrs') } />

--- a/docs/general/README.mdx
+++ b/docs/general/README.mdx
@@ -9,4 +9,5 @@ basic tools for you to get started.
 <DocCardList items={[
     findSidebarItem('/general/oasis-network/'),
     findSidebarItem('/general/manage-tokens/'),
+    findSidebarItem('/general/manage-tokens/cli/'),
 ]} />

--- a/docs/node/run-your-node/non-validator-node.md
+++ b/docs/node/run-your-node/non-validator-node.md
@@ -10,7 +10,7 @@ This guide will cover setting up your non-validator node for the Oasis Network. 
 
 ## Prerequisites
 
-Before following this guide, make sure you've followed the [Prerequisites](prerequisites) section and have the Oasis Node binary installed on your systems.
+Before following this guide, make sure you've followed the [Prerequisites](prerequisites) chapter and have the Oasis Node binary installed on your systems.
 
 ### Creating a Working Directory
 

--- a/docs/node/testnet/README.md
+++ b/docs/node/testnet/README.md
@@ -55,7 +55,7 @@ The Oasis Node is part of the Oasis Core release.
 
 ## ParaTimes
 
-This section contains parameters for various ParaTimes known to be deployed on the Testnet. Similar to the Testnet, these may be subject to frequent version upgrades and/or state resets.
+This chapter contains parameters for various ParaTimes known to be deployed on the Testnet. Similar to the Testnet, these may be subject to frequent version upgrades and/or state resets.
 
 ### Cipher
 


### PR DESCRIPTION
Let's define docs structure: part, chapter and section in README.md and use the terms consistently across the docs.