### PR TITLE
docs: Add multiple -to addresses to sapphire and emerald-dev

### DIFF
--- a/docs/dapp/emerald/writing-dapps-on-emerald.mdx
+++ b/docs/dapp/emerald/writing-dapps-on-emerald.mdx
@@ -147,11 +147,11 @@ you to use:
 
 If you prefer using the same mnemonics each time (e.g. for testing purposes)
 or to populate just a single wallet, use `-to` flag and pass the mnemonics or
-the wallet address. For example
+the wallet addresses. For example
 
 ```sh
 docker run -it -p8545:8545 -p8546:8546 ghcr.io/oasisprotocol/emerald-dev -to "bench remain brave curve frozen verify dream margin alarm world repair innocent"
-docker run -it -p8545:8545 -p8546:8546 ghcr.io/oasisprotocol/emerald-dev -to "0x75eCF0d4496C2f10e4e9aF3D4d174576Ee9010E2"
+docker run -it -p8545:8545 -p8546:8546 ghcr.io/oasisprotocol/emerald-dev -to "0x75eCF0d4496C2f10e4e9aF3D4d174576Ee9010E2,0xbDA5747bFD65F08deb54cb465eB87D40e51B197E"
 ```
 
 :::

--- a/docs/dapp/sapphire/guide.mdx
+++ b/docs/dapp/sapphire/guide.mdx
@@ -363,11 +363,11 @@ you to use:
 
 If you prefer using the same mnemonics each time (e.g. for testing purposes)
 or to populate just a single wallet, use `-to` flag and pass the mnemonics or
-the wallet address. For example
+the wallet addresses. For example
 
 ```sh
 docker run -it -p8545:8545 -p8546:8546 ghcr.io/oasisprotocol/sapphire-dev -to "bench remain brave curve frozen verify dream margin alarm world repair innocent"
-docker run -it -p8545:8545 -p8546:8546 ghcr.io/oasisprotocol/sapphire-dev -to "0x75eCF0d4496C2f10e4e9aF3D4d174576Ee9010E2"
+docker run -it -p8545:8545 -p8546:8546 ghcr.io/oasisprotocol/sapphire-dev -to "0x75eCF0d4496C2f10e4e9aF3D4d174576Ee9010E2,0xbDA5747bFD65F08deb54cb465eB87D40e51B197E"
 ```
 
 :::


### PR DESCRIPTION
Mention comma-separated `-to` addresses recently added in https://github.com/oasisprotocol/oasis-web3-gateway/pull/431.