### PR TITLE
docs: Add new Reference API URLs

### DIFF
--- a/docs/paratime/README.mdx
+++ b/docs/paratime/README.mdx
@@ -15,7 +15,7 @@ SDK].
     findSidebarItem('/paratime/minimal-runtime'),
     findSidebarItem('/paratime/modules'),
     findSidebarItem('/paratime/reproducibility'),
-    findSidebarItem('https://api.docs.oasis.io/oasis-sdk/oasis_runtime_sdk'),
+    findSidebarItem('https://api.docs.oasis.io/rust/oasis_runtime_sdk'),
 ]} />
 
 [Oasis Runtime SDK]:

--- a/sidebarCore.js
+++ b/sidebarCore.js
@@ -167,6 +167,16 @@ const sidebars = {
       label: 'ADRs',
       href: '/adrs'
     },
+    {
+      type: 'link',
+      label: 'Core Client TypeScript API',
+      href: 'https://api.docs.oasis.io/js/client',
+    },
+    {
+      type: 'link',
+      label: 'Core Client Go API',
+      href: 'https://pkg.go.dev/github.com/oasisprotocol/oasis-core/go',
+    },
   ],
 };
 

--- a/sidebarDapp.js
+++ b/sidebarDapp.js
@@ -22,6 +22,16 @@ const sidebars = {
         'dapp/sapphire/gasless',
         'dapp/sapphire/precompiles',
         'dapp/sapphire/addresses',
+        {
+          type: 'link',
+          label: 'TypeScript API',
+          href: 'https://api.docs.oasis.io/js/sapphire-paratime',
+        },
+        {
+          type: 'link',
+          label: 'Solidity API',
+          href: 'https://api.docs.oasis.io/sol/sapphire-contracts',
+        },
       ],
     },
     {
@@ -66,13 +76,8 @@ const sidebars = {
         {
           type: 'link',
           label: 'Rust API',
-          href: 'https://api.docs.oasis.io/oasis-sdk/oasis_contract_sdk',
+          href: 'https://api.docs.oasis.io/rust/oasis_contract_sdk',
         },
-        {
-          type: 'link',
-          label: 'Go API',
-          href: 'https://pkg.go.dev/github.com/oasisprotocol/oasis-sdk/client-sdk/go/client',
-        }
       ],
     },
   ],

--- a/sidebarParatime.js
+++ b/sidebarParatime.js
@@ -14,8 +14,18 @@ const sidebars = {
     'paratime/reproducibility',
     {
       type: 'link',
-      label: 'Rust API',
-      href: 'https://api.docs.oasis.io/oasis-sdk/oasis_runtime_sdk',
+      label: 'ParaTime Client TypeScript API',
+      href: 'https://api.docs.oasis.io/js/client-rt',
+    },
+    {
+      type: 'link',
+      label: 'ParaTime Client Go API',
+      href: 'https://pkg.go.dev/github.com/oasisprotocol/oasis-sdk/client-sdk/go/client',
+    },
+    {
+      type: 'link',
+      label: 'ParaTime SDK Rust API',
+      href: 'https://api.docs.oasis.io/rust/oasis_runtime_sdk',
     },
   ],
 };


### PR DESCRIPTION
This PR adds/updates links to TypeScript, Rust and Solidity API reference,

Previews:
- [dApp -> Sapphire](https://deploy-preview-549--trusting-archimedes-14c863.netlify.app/dapp/sapphire/)
- [dApp -> Cipher](https://deploy-preview-549--trusting-archimedes-14c863.netlify.app/dapp/cipher/)
- [ParaTime](https://deploy-preview-549--trusting-archimedes-14c863.netlify.app/paratime/)
- [Core](https://deploy-preview-549--trusting-archimedes-14c863.netlify.app/core/)