### PR TITLE
Update Hardhat dependency information

### DIFF
--- a/docs/dapp/opl/setup.md
+++ b/docs/dapp/opl/setup.md
@@ -30,13 +30,13 @@ Let's create a new Hardhat project.
 
 :::info
 
-Currently we are compatible with Hardhat up to `2.12.7`. You may need to
+Currently we are compatible with Hardhat up to `2.16`. You may need to
 specify the version of Hardhat to install.
 
 :::
 
 ```shell
-cd opl-secret-ballot/backend && npx hardhat
+cd opl-secret-ballot/backend && npx hardhat init
 ```
 
 When initializing the Hardhat application, we would like to use the `backend`

--- a/docs/dapp/sapphire/quickstart.mdx
+++ b/docs/dapp/sapphire/quickstart.mdx
@@ -41,7 +41,7 @@ data trove) if the operator fails to re-up before too long.
 Let's make it happen!
 
 [higher level of security]: guide.mdx#writing-secure-dapps
-[dead person's switch]: https://en.wikipedia.org/wiki/Dead_man's_switch
+[dead person's switch]: https://en.wikipedia.org/wiki/Dead_man%27s_switch
 
 ### Init a new Hardhat project
 

--- a/docs/dapp/sapphire/quickstart.mdx
+++ b/docs/dapp/sapphire/quickstart.mdx
@@ -49,7 +49,7 @@ We're going to use Hardhat, but Sapphire should be compatible with your dev
 environment of choice. Let us know if things are not as expected!
 
 1. Make & enter a new directory
-2. `npx hardhat@~2.16.0` then create a TypeScript project.
+2. `npx hardhat@~2.16.0 init` then create a TypeScript project.
 3. Add [`@oasisprotocol/sapphire-hardhat`] as dependency:
 
   ```shell npm2yarn


### PR DESCRIPTION
#### Description

Our integration is set to all minor [versions](https://github.com/oasisprotocol/sapphire-paratime/blob/5e712c1eaeb3c2fc31f44c0e875a7dbbca2b8247/integrations/hardhat/package.json#L38) including [2.17.3](https://github.com/oasisprotocol/sapphire-paratime/actions/runs/6471599726/job/17570361410), but we haven't technically published this version yet.

Also patch broken url.