### PR TITLE
docs/node/paratime-client: Update config file for 23.0

### DIFF
--- a/docs/node/run-your-node/paratime-client-node.mdx
+++ b/docs/node/run-your-node/paratime-client-node.mdx
@@ -180,31 +180,26 @@ Ubuntu 18.04 LTS (and earlier) provide overly-old `bubblewrap`. Follow _Other Di
 In order to configure the ParaTime client node, create the `/node/etc/config.yml` file with the following content:
 
 ```yaml
-datadir: /node/data
-
-log:
-  level:
-    default: info
-    tendermint: info
-    tendermint/context: error
-  format: JSON
-
+mode: client
+common:
+    data_dir: /node/data
+    log:
+        format: JSON
+        level:
+            cometbft: info
+            cometbft/context: error
+            default: info
 genesis:
-  file: /node/etc/genesis.json
-
-consensus:
-  tendermint:
-    p2p:
+    file: /node/etc/genesis.json
+p2p:
+    seeds:
       # List of seed nodes to connect to.
       # NOTE: You can add additional seed nodes to this list if you want.
-      seed:
-        - "{{ seed_node_address }}"
-
+        - {{ seed_node_address }}
 runtime:
-  mode: client
-  paths:
     # Paths to ParaTime bundles for all of the supported ParaTimes.
-    - "{{ runtime_orc_path }}"
+    paths:
+        - {{ runtime_orc_path }}
 ```
 
 Before using this configuration you should collect the following information to replace  the  variables present in the configuration file:.


### PR DESCRIPTION
Migrated with `oasis-node config migrate` and updated variables.