### PR TITLE
docs/node/ias: Update config file for 23.0

### DIFF
--- a/docs/node/run-your-node/ias-proxy.md
+++ b/docs/node/run-your-node/ias-proxy.md
@@ -58,18 +58,12 @@ In order to configure the IAS proxy create the `/node/ias/config.yml` file with
 the following content:
 
 ```yaml
-datadir: /node/ias
-
-log:
-  level:
-    default: info
-  format: JSON
-
-ias:
-  production: true
-
-grpc:
-  port: 8650
+common:
+    data_dir: /node/ias
+    log:
+        format: JSON
+        level:
+            default: info
 ```
 
 ## Starting the IAS Proxy
@@ -77,7 +71,11 @@ grpc:
 You can start the IAS Proxy using the following command:
 
 ```bash
-oasis-node ias proxy --config /node/ias/config.yml --address unix:{{ oasis_node_socket }}
+oasis-node ias proxy \
+  --config /node/ias/config.yml \
+  --address unix:{{ oasis_node_socket }} \
+  --ias.production true \
+  --grpc.port 8650
 ```
 
 Before using this configuration you should collect the following information to


### PR DESCRIPTION
Migrated with `oasis-node config migrate`

I do not know if the script migrated config correctly. This got omitted:

```
grpc:
  port: 8650
```