### PR TITLE
docs: Migrate dapp/sapphire/precompiles chapter to api.docs.oasis.io

### DIFF
--- a/docs/dapp/sapphire/precompiles.md
+++ b/docs/dapp/sapphire/precompiles.md
@@ -1,1 +1,0 @@
-../../../external/sapphire-paratime/docs/precompiles.md

--- a/redirects.ts
+++ b/redirects.ts
@@ -274,6 +274,10 @@ export const redirectsOptions: Options = {
             to: '/node/mainnet/eden-upgrade',
             from: '/node/mainnet/e-upgrade' // #600 Add 23.0 upgrade's name
         },
+        {
+            to: 'https://api.docs.oasis.io/sol/sapphire-contracts',
+            from: '/dapp/sapphire/precompiles' // #688 Migrate dapp/sapphire/precompiles chapter to api.docs.oasis.io
+        },
     ],
     createRedirects(existingPath) {
         // #119 Add /oasis-core/adr/* -> /adrs/* redirection

--- a/sidebarDapp.ts
+++ b/sidebarDapp.ts
@@ -20,7 +20,6 @@ export const sidebarDapp: SidebarsConfig = {
         'dapp/sapphire/browser',
         'dapp/sapphire/authentication',
         'dapp/sapphire/gasless',
-        'dapp/sapphire/precompiles',
         'dapp/sapphire/addresses',
         'dapp/sapphire/security',
         {


### PR DESCRIPTION
Merge after https://github.com/oasisprotocol/sapphire-paratime/pull/243

This PR:
- removes /dapp/sapphire/precompiles chapter
- adds redirect to https://api.docs.oasis.io/sol/sapphire-contracts package instead