### PR TITLE
bump testnet web3 gateway versions to v4.0.3-rc1

### DIFF
--- a/docs/node/testnet/README.md
+++ b/docs/node/testnet/README.md
@@ -83,7 +83,7 @@ Feel free to use other IAS proxies besides the ones provided here or [run your o
 * Runtime bundle version (or [build your own](https://github.com/oasisprotocol/emerald-paratime/tree/v11.0.0-testnet#building)):
   * [11.0.0-testnet](https://github.com/oasisprotocol/emerald-paratime/releases/tag/v11.0.0-testnet)
 * Web3 Gateway version:
-  * [4.0.2](https://github.com/oasisprotocol/oasis-web3-gateway/releases/tag/v4.0.2)
+  * [4.0.3-rc1](https://github.com/oasisprotocol/oasis-web3-gateway/releases/tag/v4.0.3-rc1)
 
 ### Sapphire
 
@@ -95,7 +95,7 @@ Feel free to use other IAS proxies besides the ones provided here or [run your o
   * [0.7.0-testnet](https://github.com/oasisprotocol/sapphire-paratime/releases/tag/v0.7.0-testnet)
   * [0.7.1-testnet](https://github.com/oasisprotocol/sapphire-paratime/releases/tag/v0.7.1-testnet)
 * Web3 Gateway version:
-  * [4.0.2](https://github.com/oasisprotocol/oasis-web3-gateway/releases/tag/v4.0.2)
+  * [4.0.3-rc1](https://github.com/oasisprotocol/oasis-web3-gateway/releases/tag/v4.0.3-rc1)
 * IAS proxy address:
   * `y4XO1ZETqgtHeZzLLmJLYAzpEfdGSJLvtd8bhIz+v3s=@34.86.197.181:8650`
   * `jaFE5Lq6GS76ya1V7a+XlGQTgttAagXEtknO4Tv1wLs=@185.56.138.83:8650`


### PR DESCRIPTION
The sapphire update is more relevant, but doesn't hurt updating emerald also.