### PR TITLE
mention publicly exposing ports in node configuration pages

### DIFF
--- a/docs/node/run-your-node/keymanager-node/README.md
+++ b/docs/node/run-your-node/keymanager-node/README.md
@@ -130,8 +130,8 @@ Before using this configuration you should collect the following information to 
 
 :::caution
 
-Make sure the `worker.p2p.port` (default: `9200`) port is exposed and publicly
-accessible on the internet (for `TCP` traffic).
+Make sure the `consensus` port (default: `26656`) and `p2p.port` (default: `9200`) are exposed and publicly
+accessible on the internet (for `TCP` and `UDP` traffic).
 
 :::
 

--- a/docs/node/run-your-node/non-validator-node.mdx
+++ b/docs/node/run-your-node/non-validator-node.mdx
@@ -73,6 +73,13 @@ Before using this configuration you should collect the following information to 
 
   You can find the current Oasis Seed Node address in the Network Parameters page ([Mainnet], [Testnet]).
 
+:::caution
+
+Make sure the `consensus` port (default: `26656`) and `p2p.port` (default: `9200`) are exposed and publicly
+accessible on the internet (for `TCP` and `UDP` traffic).
+
+:::
+
 ## Starting the Oasis Node
 
 You can start the node by running the following command:

--- a/docs/node/run-your-node/paratime-client-node.mdx
+++ b/docs/node/run-your-node/paratime-client-node.mdx
@@ -209,6 +209,13 @@ Before using this configuration you should collect the following information to 
 * `{{ runtime_orc_path }}`: Path to the [ParaTime bundle](paratime-client-node.mdx#the-paratime-bundle) of the form `/node/runtimes/foo-paratime.orc`.
   * You can find the current Oasis-supported ParaTimes in the Network Parameters page ([Mainnet], [Testnet]).
 
+:::caution
+
+Make sure the `consensus` port (default: `26656`) and `p2p.port` (default: `9200`) are exposed and publicly
+accessible on the internet (for `TCP` and `UDP` traffic).
+
+:::
+
 ## Starting the Oasis Node
 
 You can start the node by running the following command:

--- a/docs/node/run-your-node/paratime-node.mdx
+++ b/docs/node/run-your-node/paratime-node.mdx
@@ -336,8 +336,8 @@ Before using this configuration you should collect the following information to 
 
 :::caution
 
-Make sure the `p2p.port` (default: `9200`) port is exposed and publicly
-accessible on the internet (for `TCP` traffic).
+Make sure the `consensus` port (default: `26656`) and `p2p.port` (default: `9200`) are exposed and publicly
+accessible on the internet (for `TCP` and `UDP` traffic).
 
 :::
 

--- a/docs/node/run-your-node/seed-node.md
+++ b/docs/node/run-your-node/seed-node.md
@@ -53,6 +53,13 @@ genesis:
     file: /node/etc/genesis.json
 ```
 
+:::caution
+
+Make sure the `consensus` port (default: `26656`) and `p2p.port` (default: `9200`) are exposed and publicly
+accessible on the internet (for `TCP` and `UDP` traffic).
+
+:::
+
 ## Starting the Oasis Node
 
 You can start the node by running the following command:

--- a/docs/node/run-your-node/sentry-node.md
+++ b/docs/node/run-your-node/sentry-node.md
@@ -219,3 +219,10 @@ sentry:
         - {{ sentry_node_grpc_public_key }}@{{ sentry_node_private_ip }}:9009
 ```
 
+
+:::caution
+
+Make sure the `consensus` port (default: `26656`) and `p2p.port` (default: `9200`) are exposed and publicly
+accessible on the internet (for `TCP` and `UDP` traffic).
+
+:::

--- a/docs/node/run-your-node/validator-node.mdx
+++ b/docs/node/run-your-node/validator-node.mdx
@@ -226,6 +226,13 @@ registration:
     entity: /node/etc/entity.json
 ```
 
+:::caution
+
+Make sure the `consensus` port (default: `26656`) and `p2p.port` (default: `9200`) are exposed and publicly
+accessible on the internet (for `TCP` and `UDP` traffic).
+
+:::
+
 ## Starting the Oasis Node
 
 You can start the node by simply running the command:


### PR DESCRIPTION
Mention both TCP and UDP (currently TCP is used for both, but in future QUIC could be used, so make this more future proof).

Probably should add the note also to the paratime-client-node and non-validator node? Since the network will benefit from more nodes having the p2p ports open, even if these are client nodes.