### PR TITLE
CSS: Rebranding followup

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -91,7 +91,7 @@ const config: Config = {
         logo: {
           alt: 'Oasis Docs',
           src: 'img/logo.svg',
-          //srcDark: 'img/logo_dark.svg',
+          srcDark: 'img/logo_dark.svg', // Workaround for browsers that don't support @media (prefers-color-scheme: dark) in external SVGs.
           // Uncomment src and style below to enable christmas mode ;)
           //src: 'img/logo_christmas.png',
           //style: {height: '48px', maxWidth: '58px', marginTop: '-15px', marginLeft: '-15px'},

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -118,6 +118,13 @@ html[data-theme='dark'] .docusaurus-highlight-code-line {
   border-radius: 0;
   border: 1px solid black;
 }
+/* The primary dark mode color is too aggressive for the eye when hovering over
+   the hits. Ideally we should color the matched substrings with the primary
+   color, but highlight it with --ifm-navbar-search-input-background-color when
+   hovering over. Temporary fix: Use a less aggressive color for everything. */
+html[data-theme="dark"] {
+  --search-local-highlight-color: #3ec8ff;
+}
 
 /* Make docccard and navcard border stronger */
 .card,

--- a/static/img/logo_dark.svg
+++ b/static/img/logo_dark.svg
@@ -3,13 +3,7 @@
   <defs>
     <style>
       path {
-        fill: #0500e2;
-        stroke-width: 0px;
-      }
-      @media (prefers-color-scheme: dark) {
-        path {
-          fill: white;
-        }
+        fill: white;
       }
     </style>
   </defs>


### PR DESCRIPTION
- logo: Workaround for browsers that don't pass CSS to external SVGs
- search: Use less aggressive blue for highlighting the hits

[PREVIEW](https://deploy-preview-795--oasisprotocol-docs.netlify.app/)