### PR TITLE
docs/node: Mention other legacy SGX drivers and describe troubleshooting when AESM could not be contacted

### DIFF
--- a/docs/node/run-your-node/prerequisites/set-up-trusted-execution-environment-tee.md
+++ b/docs/node/run-your-node/prerequisites/set-up-trusted-execution-environment-tee.md
@@ -485,7 +485,7 @@ Detecting SGX, this may take a minute...
   ？ CPU configuration
   ✘  Able to launch production mode enclave
 ✔  SGX system software
-  ✔  SGX kernel device (/dev/isgx)
+  ✔  SGX kernel device (/dev/sgx_enclave)
   ✘  libsgx_enclave_common
   ✔  AESM service
   ✔  Able to launch enclaves

--- a/docs/node/run-your-node/prerequisites/set-up-trusted-execution-environment-tee.md
+++ b/docs/node/run-your-node/prerequisites/set-up-trusted-execution-environment-tee.md
@@ -45,10 +45,12 @@ install a compatible SGX driver.
 
 ### Verification
 
-Make sure that the one of the SGX devices exists (the exact device name depends
-on which driver is being used):
+Make sure that one of the following SGX devices exists (the exact device name
+depends on which driver is being used):
 
 * `/dev/sgx_enclave` (since Linux kernel 5.11)
+* `/dev/sgx/enclave` (legacy driver)
+* `/dev/sgx` (legacy driver)
 * `/dev/isgx` (legacy driver)
 
 ## Ensure Proper SGX Device Permissions

--- a/docs/node/run-your-node/prerequisites/set-up-trusted-execution-environment-tee.md
+++ b/docs/node/run-your-node/prerequisites/set-up-trusted-execution-environment-tee.md
@@ -514,6 +514,26 @@ development server.
 See  [the general troubleshooting section](../troubleshooting.md), before
 proceeding with ParaTime node-specific troubleshooting.
 
+### AESM could not be contacted
+
+If running `sgx-detect --verbose` reports:
+
+```
+🕮  SGX system software > AESM service
+AESM could not be contacted. AESM is needed for launching enclaves and generating attestations.
+
+Please check your AESM installation.
+
+debug: error communicating with aesm
+debug: cause: Connection refused (os error 111)
+
+More information: https://edp.fortanix.com/docs/installation/help/#aesm-service
+```
+
+Ensure  you have completed all the necessary installation steps outlined in either
+[DCAP Attestation](#dcap-attestation) or [EPID attestation](#legacy-epid-attestation)
+sections.
+
 ### AESM: error 30
 
 If you are encountering the following error message in your node's logs:


### PR DESCRIPTION
The updates here mention three other possible legacy SGX devices to highlight changes related to legacy SGX drivers over the years. Additionally, resolving the "AESM could not be contacted" error (can occur when executing `sgx-detect --verbose` command) is described.

[Preview](https://deploy-preview-798--oasisprotocol-docs.netlify.app/node/run-your-node/prerequisites/set-up-trusted-execution-environment-tee)