### PR TITLE
docs: Add Sapphire deployment pattern section

### DIFF
--- a/docs/dapp/sapphire/deployment.md
+++ b/docs/dapp/sapphire/deployment.md
@@ -1,0 +1,1 @@
+../../../external/sapphire-paratime/docs/deployment.md

--- a/sidebarDapp.ts
+++ b/sidebarDapp.ts
@@ -21,6 +21,7 @@ export const sidebarDapp: SidebarsConfig = {
         'dapp/sapphire/authentication',
         'dapp/sapphire/gasless',
         'dapp/sapphire/addresses',
+        'dapp/sapphire/deployment',
         'dapp/sapphire/security',
         {
           type: 'link',


### PR DESCRIPTION
## Description

Add necessary file reference. Blocked by https://github.com/oasisprotocol/sapphire-paratime/pull/313.