### PR TITLE
docs/node/run-your-node: Use FQCN for Ansible user module

### DIFF
--- a/docs/node/run-your-node/prerequisites/system-configuration.mdx
+++ b/docs/node/run-your-node/prerequisites/system-configuration.mdx
@@ -59,7 +59,7 @@ Add the following task to your playbook:
 
 ```yml
 - name: Create oasis user
-  user:
+  ansible.builtin.user:
     name: oasis
     comment: Oasis Services user
     system: yes


### PR DESCRIPTION
Using fully-qualified collection names (FQCN) in Ansible content is a [recommended practice](https://docs.ansible.com/ansible/latest/tips_tricks/ansible_tips_tricks.html#use-fully-qualified-collection-names). So, this minor update suggests using [`ansible.builtin.user`](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/user_module.html) (with FQCN) instead of `user` module (without FQCN) when creating a new `oasis` user. 