### PR TITLE
docs: Add Indexers sections

### DIFF
--- a/docs/dapp/README.mdx
+++ b/docs/dapp/README.mdx
@@ -70,12 +70,23 @@ Public gRPC endpoints (in alphabetic order):
 
 ## Consensus Layer Block Explorers
 
-| Provider                    | Mainnet URL               | Testnet URL                   |
-|-----------------------------|---------------------------|-------------------------------|
-| [Bit Cat]                   | https://www.oasisscan.com | https://testnet.oasisscan.com |
-| [Oasis Protocol Foundation] | *Coming soon*             | *Coming soon*                 |
+| Name (Provider)                              | Mainnet URL               | Testnet URL                   |
+|----------------------------------------------|---------------------------|-------------------------------|
+| Oasis Scan ([Bit Cat])                       | https://www.oasisscan.com | https://testnet.oasisscan.com |
+| Oasis Explorer ([Oasis Protocol Foundation]) | *Coming soon*             | *Coming soon*                 |
 
 [Bit Cat]: https://www.bitcat365.com/
+
+## Consensus Layer Indexers
+
+| Name (Provider)                           | Mainnet URL                            | Testnet URL                            | Documentation                              |
+|-------------------------------------------|----------------------------------------|----------------------------------------|--------------------------------------------|
+| Oasis Scan ([Bit Cat])                    | `https://api.oasisscan.com/mainnet/v2` | `https://api.oasisscan.com/testnet/v2` | [Mainnet API][OasisScan-Mainnet-docs], [Testnet API][OasisScan-Testnet-docs] |
+| Oasis Nexus ([Oasis Protocol Foundation]) | `https://nexus.oasis.io/v1`            | `https://testnet.nexus.oasis.io/v1`    | [API][Nexus-docs]                          |
+
+[Nexus-docs]: https://nexus.oasis.io/v1/spec/v1.html
+[OasisScan-Testnet-docs]: https://api.oasisscan.com/testnet/swagger-ui/
+[OasisScan-Mainnet-docs]: https://api.oasisscan.com/mainnet/swagger-ui/
 
 ## Rosetta Endpoints
 
@@ -83,12 +94,11 @@ Public gRPC endpoints (in alphabetic order):
 |-----------------------------|-------------------------------------------|-------------------------------------------|
 | [Oasis Protocol Foundation] | `https://rosetta.oasis.io/api/mainnet/v1` | `https://rosetta.oasis.io/api/testnet/v1` |
 
+:::note
 
-:::tip
-
-If you are running your own Oasis client node endpoint, a block explorer or the
-Rosetta gateway and you wish to be added to the public list above, open an issue
-at [github.com/oasisprotocol/docs].
+If you are running your own Oasis client node endpoint, a block explorer, an
+indexer, or the Rosetta gateway and wish to be added to these docs, open an
+issue at [github.com/oasisprotocol/docs].
 
 :::
 

--- a/docs/dapp/cipher/README.mdx
+++ b/docs/dapp/cipher/README.mdx
@@ -67,16 +67,37 @@ one of the public endpoints below (in alphabetic order):
 
 ## Block Explorers
 
-No block explorers are available for Cipher yet. Consider debugging the Cipher
-blocks using the [`oasis paratime show`] command in [Oasis CLI].
+| Name/Provider               | Mainnet URL                               | Testnet URL                               | EIP-3091 compatible |
+|-----------------------------|-------------------------------------------|-------------------------------------------|---------------------|
+| Oasis Scan ([Bit Cat])                      | [https://www.oasisscan.com/paratimes/000…7cb](https://www.oasisscan.com/paratimes/000000000000000000000000000000000000000000000000e199119c992377cb) | [https://testnet.oasisscan.com/paratimes/000…000](https://testnet.oasisscan.com/paratimes/0000000000000000000000000000000000000000000000000000000000000000) | No |
+
+[Bit Cat]: https://www.bitcat365.com/
+
+:::tip
+
+Only rudimentary block explorer features exist for Cipher. Consider debugging
+the Cipher transactions using the [`oasis paratime show`] command part of the
+[Oasis CLI].
+
+:::
 
 [`oasis paratime show`]: ../../general/manage-tokens/cli/paratime.md#show
 [Oasis CLI]: ../../general/manage-tokens/cli/README.md
 
-:::tip
+## Indexers
 
-If you are running your own Cipher endpoint and you wish to be added to the
-public list above, open an issue at [github.com/oasisprotocol/docs].
+| Name (Provider)                           | Mainnet URL                                           | Testnet URL                          | Documentation     |
+|-------------------------------------------|-------------------------------------------------------|--------------------------------------|-------------------|
+| Oasis Scan ([Bit Cat])                    | `https://api.oasisscan.com/mainnet/v2`                | `https://api.oasisscan.com/testnet/v2` | [Mainnet Runtime API][OasisScan-Mainnet-docs], [Testnet Runtime API][OasisScan-Testnet-docs] |
+
+[OasisScan-Testnet-docs]: https://api.oasisscan.com/testnet/swagger-ui/#/runtime-controller
+[OasisScan-Mainnet-docs]: https://api.oasisscan.com/mainnet/swagger-ui/#/runtime-controller
+
+:::note
+
+If you are running your own Cipher endpoint, a block explorer, or an indexer
+and wish to be added to these docs, open an issue at
+[github.com/oasisprotocol/docs].
 
 :::
 

--- a/docs/dapp/emerald/README.mdx
+++ b/docs/dapp/emerald/README.mdx
@@ -78,14 +78,36 @@ dedicated RPC endpoints, consider the following providers (in alphabetic order):
 
 ## Block Explorers
 
-| Provider                    | Mainnet URL                               | Testnet URL                               | EIP-3091 compatible |
+| Name/Provider               | Mainnet URL                               | Testnet URL                               | EIP-3091 compatible |
 |-----------------------------|-------------------------------------------|-------------------------------------------|---------------------|
-| [Oasis Protocol Foundation] | https://explorer.oasis.io/mainnet/emerald | https://explorer.oasis.io/testnet/emerald | Yes                 |
+| [Oasis Explorer][Oasis Protocol Foundation] | https://explorer.oasis.io/mainnet/emerald | https://explorer.oasis.io/testnet/emerald | Yes                 |
+| Oasis Scan ([Bit Cat])                      | [https://www.oasisscan.com/paratimes/000…87f](https://www.oasisscan.com/paratimes/000000000000000000000000000000000000000000000000e2eaa99fc008f87f) | [https://testnet.oasisscan.com/paratimes/000…ca7](https://testnet.oasisscan.com/paratimes/00000000000000000000000000000000000000000000000072c8215e60d5bca7) | No |
 
-:::tip
+[Bit Cat]: https://www.bitcat365.com/
 
-If you are running your own Emerald endpoint or a block explorer, and you wish
-to be added to the public list above, open an issue at
+## Indexers
+
+| Name (Provider)                           | Mainnet URL                                           | Testnet URL                          | Documentation     |
+|-------------------------------------------|-------------------------------------------------------|--------------------------------------|-------------------|
+| [Covalent]                                | `https://api.covalenthq.com/v1/oasis-emerald-mainnet` | *N/A*                                | [Unified API docs][Covalent-docs] |
+| Oasis Nexus ([Oasis Protocol Foundation]) | `https://nexus.oasis.io/v1/`                          | `https://testnet.nexus.oasis.io/v1/` | [API][Nexus-docs] |
+| Oasis Scan ([Bit Cat])                    | `https://api.oasisscan.com/mainnet/v2`                | `https://api.oasisscan.com/testnet/v2` | [Mainnet Runtime API][OasisScan-Mainnet-docs], [Testnet Runtime API][OasisScan-Testnet-docs] |
+| [SubQuery Network][SubQuery]              | *N/A*                                                 | *N/A*                                | [SubQuery Academy][SubQuery-docs], [QuickStart][SubQuery-quickstart], [Starter project][SubQuery-starter] |
+
+[Covalent]: https://www.covalenthq.com/
+[Covalent-docs]: https://www.covalenthq.com/docs/unified-api/
+[Nexus-docs]: https://nexus.oasis.io/v1/spec/v1.html
+[OasisScan-Testnet-docs]: https://api.oasisscan.com/testnet/swagger-ui/#/runtime-controller
+[OasisScan-Mainnet-docs]: https://api.oasisscan.com/mainnet/swagger-ui/#/runtime-controller
+[SubQuery]: https://subquery.network
+[SubQuery-docs]: https://academy.subquery.network/
+[SubQuery-quickstart]: https://academy.subquery.network/quickstart/quickstart.html
+[SubQuery-starter]: https://github.com/subquery/ethereum-subql-starter/tree/main/Oasis/oasis-emerald-starter
+
+:::note
+
+If you are running your own Emerald endpoint, a block explorer, or an indexer
+and wish to be added to these docs, open an issue at
 [github.com/oasisprotocol/docs].
 
 :::

--- a/docs/dapp/sapphire/README.mdx
+++ b/docs/dapp/sapphire/README.mdx
@@ -61,7 +61,7 @@ You can connect to one of the public Web3 gateways below (in alphabetic order):
 
 | Provider                    | Mainnet RPC URLs                                                        | Testnet RPC URLs                                                                           | Supports Confidential Queries |
 |-----------------------------|-------------------------------------------------------------------------|--------------------------------------------------------------------------------------------|-------------------------------|
-| [1RPC]                      | <S rpcs={['https://1rpc.io/oasis/sapphire']} />                         | N/A                                                                                        | Yes                           |
+| [1RPC]                      | <S rpcs={['https://1rpc.io/oasis/sapphire']} />                         | *N/A*                                                                                      | Yes                           |
 | [Oasis Protocol Foundation] | <S rpcs={['https://sapphire.oasis.io','wss://sapphire.oasis.io/ws']} /> | <ST rpcs={['https://testnet.sapphire.oasis.io','wss://testnet.sapphire.oasis.io/ws']} /> | Yes                           |
 
 [Oasis Protocol Foundation]: https://oasisprotocol.org
@@ -84,14 +84,39 @@ dedicated RPC endpoints, consider the following providers (in alphabetic order):
 
 ## Block Explorers
 
-| Provider                    | Mainnet URL                                | Testnet URL                                | EIP-3091 compatible |
-|-----------------------------|--------------------------------------------|--------------------------------------------|---------------------|
-| [Oasis Protocol Foundation] | https://explorer.oasis.io/mainnet/sapphire | https://explorer.oasis.io/testnet/sapphire | Yes                 |
+| Name (Provider)                               | Mainnet URL                                | Testnet URL                                | EIP-3091 compatible |
+|-----------------------------------------------|--------------------------------------------|--------------------------------------------|---------------------|
+| Oasis Explorer ([Oasis Protocol Foundation])  | https://explorer.oasis.io/mainnet/sapphire | https://explorer.oasis.io/testnet/sapphire | Yes                 |
+| Oasis Scan ([Bit Cat])                        | [https://www.oasisscan.com/paratimes/000…279](https://www.oasisscan.com/paratimes/000000000000000000000000000000000000000000000000f80306c9858e7279) | [https://testnet.oasisscan.com/paratimes/000…f6c](https://testnet.oasisscan.com/paratimes/000000000000000000000000000000000000000000000000a6d1e3ebf60dff6c) | No |
 
-:::tip
+[Bit Cat]: https://www.bitcat365.com/
 
-If you are running your own Sapphire endpoint or a block explorer, and you wish
-to be added to the public list above, open an issue at
+## Indexers
+
+| Name (Provider)      | Mainnet URL                                                    | Testnet URL                                            | Documentation                              |
+|--------------------|------------------------------------------------------------------|--------------------------------------------------------|--------------------------------------------|
+| [Covalent]                   | `https://api.covalenthq.com/v1/oasis-sapphire-mainnet` | `https://api.covalenthq.com/v1/oasis-sapphire-testnet` | [Unified API docs][Covalent-docs]          |
+| [Goldsky Subgraph][Goldsky]  | *N/A*                                                  | *N/A*                                                  | [Documentation site][Goldsky-docs]         |
+| Oasis Nexus ([Oasis Protocol Foundation]) | `https://nexus.oasis.io/v1/`              | `https://testnet.nexus.oasis.io/v1/`                   | [API][Nexus-docs]                          |
+| Oasis Scan ([Bit Cat])       | `https://api.oasisscan.com/mainnet/v2`                 | `https://api.oasisscan.com/testnet/v2`                 | [Mainnet Runtime API][OasisScan-Mainnet-docs], [Testnet Runtime API][OasisScan-Testnet-docs] |
+| [SubQuery Network][SubQuery] | *N/A*                                                  | *N/A*                                                  | [SubQuery Academy][SubQuery-docs], [QuickStart][SubQuery-quickstart], [Starter project][SubQuery-starter] |
+
+[Covalent]: https://www.covalenthq.com/
+[Covalent-docs]: https://www.covalenthq.com/docs/unified-api/
+[Nexus-docs]: https://nexus.oasis.io/v1/spec/v1.html
+[Goldsky]: https://goldsky.com
+[Goldsky-docs]: https://docs.goldsky.com
+[OasisScan-Testnet-docs]: https://api.oasisscan.com/testnet/swagger-ui/#/runtime-controller
+[OasisScan-Mainnet-docs]: https://api.oasisscan.com/mainnet/swagger-ui/#/runtime-controller
+[SubQuery]: https://subquery.network
+[SubQuery-docs]: https://academy.subquery.network/
+[SubQuery-quickstart]: https://academy.subquery.network/quickstart/quickstart.html
+[SubQuery-starter]: https://github.com/subquery/ethereum-subql-starter/tree/main/Oasis/oasis-sapphire-starter
+
+:::note
+
+If you are running your own Sapphire endpoint, a block explorer, or an indexer
+and wish to be added to these docs, open an issue at
 [github.com/oasisprotocol/docs].
 
 :::


### PR DESCRIPTION
Adds the Indexers section for Sapphire, Emerald, Cipher, and consensus layer.

[PREVIEW](https://deploy-preview-838--oasisprotocol-docs.netlify.app/dapp/)