### PR TITLE
submodule: Bump Oasis Core to 24.0.x branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "external/oasis-core"]
 	path = external/oasis-core
 	url = https://github.com/oasisprotocol/oasis-core
-	branch = stable/23.0.x
+	branch = stable/24.0.x
 [submodule "external/oasis-sdk"]
 	path = external/oasis-sdk
 	url = https://github.com/oasisprotocol/oasis-sdk


### PR DESCRIPTION
- Sets the `oasis-core` external repo to track the new `stable/24.0.x` branch.
- Checks out the latest Oasis Core's `stable/24.0.x` branch commit.