### PR TITLE
docs/node: Add ID for Sapphire on Mainnet for Web3 Gateway docs

### DIFF
--- a/docs/node/web3.mdx
+++ b/docs/node/web3.mdx
@@ -81,6 +81,7 @@ In the config above replace `{{ ... }}` placeholders with actual ParaTime IDs:
   * Emerald on [Mainnet][mainnet-emerald]: `000000000000000000000000000000000000000000000000e2eaa99fc008f87f`
   * Emerald on [Testnet][testnet-emerald]: `00000000000000000000000000000000000000000000000072c8215e60d5bca7`
 * `{{ sapphire_paratime_id }}`:
+  * Sapphire on [Mainnet][mainnet-sapphire]: `000000000000000000000000000000000000000000000000f80306c9858e7279`
   * Sapphire on [Testnet][testnet-sapphire]: `000000000000000000000000000000000000000000000000a6d1e3ebf60dff6c`
 
 ### PostgreSQL
@@ -165,6 +166,7 @@ Use the following placeholder values:
 - `{{ chain_id }}`: The chain ID of your EVM network:
   - Emerald on [Mainnet][emerald-mainnet]: `42262`
   - Emerald on [Testnet][emerald-testnet]: `42261`
+  - Sapphire on [Mainnet][sapphire-mainnet]: `23294`
   - Sapphire on [Testnet][sapphire-testnet]: `23295`
 
 :::tip
@@ -267,10 +269,12 @@ extended downtime while the Web3 Gateway is reindexing the blocks.
 [github-releases]: https://github.com/oasisprotocol/oasis-web3-gateway/releases
 [Mainnet]: mainnet/README.md
 [mainnet-emerald]: mainnet/README.md#emerald
+[mainnet-sapphire]: mainnet/README.md#sapphire
 [Oasis archive node]: run-your-node/archive-node.md
 [README.md]: https://github.com/oasisprotocol/oasis-web3-gateway/blob/main/README.md#building-and-testing
 [Sapphire]: ../dapp/sapphire/README.mdx
 [sapphire-testnet]: ../dapp/sapphire/README.mdx#testnet
+[sapphire-mainnet]: ../dapp/sapphire/README.mdx#mainnet
 [system service]: run-your-node/prerequisites/system-configuration.mdx#create-a-user
 [Testnet]: testnet/README.md
 [testnet-emerald]: testnet/README.md#emerald


### PR DESCRIPTION
Adding missing ParaTime ID and chain ID for Sapphire on Mainnet to Web3 Gateway docs.