### PR TITLE
docs/node: Update Web3 Gateway version to 5.1.0 for Mainnet

### DIFF
--- a/docs/node/mainnet/README.md
+++ b/docs/node/mainnet/README.md
@@ -84,7 +84,7 @@ Feel free to use other IAS proxies besides the one provided here or
 * Runtime bundle version (or [build your own](https://github.com/oasisprotocol/emerald-paratime/tree/v11.0.0#building)):
   * [11.0.0](https://github.com/oasisprotocol/emerald-paratime/releases/tag/v11.0.0)
 * Web3 Gateway version:
-  * [5.0.1](https://github.com/oasisprotocol/oasis-web3-gateway/releases/tag/v5.0.1)
+  * [5.1.0](https://github.com/oasisprotocol/oasis-web3-gateway/releases/tag/v5.1.0)
 
 :::info
 
@@ -102,7 +102,7 @@ the public Web3 endpoint.
 * Runtime bundle version:
   * [0.7.3](https://github.com/oasisprotocol/sapphire-paratime/releases/tag/v0.7.3)
 * Oasis Web3 Gateway version:
-  * [5.0.1](https://github.com/oasisprotocol/oasis-web3-gateway/releases/tag/v5.0.1)
+  * [5.1.0](https://github.com/oasisprotocol/oasis-web3-gateway/releases/tag/v5.1.0)
 * IAS proxy address:
   * `tnTwXvGbbxqlFoirBDj63xWtZHS20Lb3fCURv0YDtYw=@34.86.108.137:8650`
   * `tuDyXwaajTEbNWb1QIlf8FWHsdkaB4W1+TjzP1QID/U=@131.153.243.17:8650`


### PR DESCRIPTION
Updating preffered Mainnet Web3 Gateway version to `5.1.0`.