### PR TITLE
node: Add missing links to the Network Parameters page

### DIFF
--- a/docs/node/genesis-doc.md
+++ b/docs/node/genesis-doc.md
@@ -1,7 +1,7 @@
 # Genesis Document
 
 A genesis document contains the initial state of an Oasis Network, and all the
-necessary information for launching that particular network (i.g. [Mainnet],
+necessary information for launching that particular network (e.g. [Mainnet],
 [Testnet]).
 
 :::info
@@ -30,10 +30,10 @@ Up to date information about the current genesis file and the current genesis
 document's hash can be found on the Network Parameters page ([Mainnet],
 [Testnet]).
 
+:::
+
 [Mainnet]: mainnet/README.md
 [Testnet]: testnet/README.md
-
-:::
 
 ## Parameters
 

--- a/docs/node/run-your-node/validator-node.mdx
+++ b/docs/node/run-your-node/validator-node.mdx
@@ -173,6 +173,9 @@ of that machine.
 
 To use this configuration, save it in the `/node/etc/config.yml` file:
 
+[Mainnet]: ../mainnet/README.md
+[Testnet]: ../testnet/README.md
+
 ```yaml title="/node/etc/config.yml"
 mode: validator
 common:


### PR DESCRIPTION
Adding missing links to the Network Parameters page in `docs/node`.