### PR TITLE
docs/node: Add consensus.GetParameters query for gRPC proxy

### DIFF
--- a/docs/node/grpc.mdx
+++ b/docs/node/grpc.mdx
@@ -112,6 +112,7 @@ static_resources:
     GetChainContext|\
     GetGenesisDocument|\
     GetNextBlockState|\
+    GetParameters|\
     GetSignerNonce|\
     GetStatus|\
     GetTransactions|\


### PR DESCRIPTION
Adding the `consensus.GetParameters` endpoint to the example Envoy gRPC-web proxy configuration in the docs.