### PR TITLE
Handle repeated AddToMetaMask clicks

### DIFF
--- a/src/AddToMetaMask.tsx
+++ b/src/AddToMetaMask.tsx
@@ -18,6 +18,7 @@ const AddToMetaMask = (props: {
           if (!window.ethereum?.request) {
             return alert('Have you installed MetaMask yet? If not, please do so.\n\nComputer: Once it is installed, you will be able to add the ParaTime to your MetaMask.\n\nPhone: Open the website through your MetaMask Browser to add the ParaTime.')
           }
+          const startTime = Date.now()
           window.ethereum.request({
             method: 'wallet_addEthereumChain',
             params: [
@@ -34,7 +35,9 @@ const AddToMetaMask = (props: {
               },
             ],
           }).then(response => {
-            if (response === null) alert('Added')
+            // XXX: A workaround to figure out if the RPC already exists.
+            const isAutomatedResponse = Date.now() - startTime < 100
+            if (response === null && isAutomatedResponse) alert(`The ${props.name} RPC already added.`)
           })
         }}
       >

--- a/src/AddToMetaMask.tsx
+++ b/src/AddToMetaMask.tsx
@@ -33,6 +33,8 @@ const AddToMetaMask = (props: {
                 blockExplorerUrls: props.be,
               },
             ],
+          }).then(response => {
+            if (response === null) alert('Added')
           })
         }}
       >


### PR DESCRIPTION
If user already has a chain added in metamask, then button does nothing. Added a message

Before, After:

[before,after.webm](https://github.com/oasisprotocol/docs/assets/3758846/a8cacfcf-a2c1-47ef-b2f2-de2a7ec8f90c)
