### PR TITLE
dapp: Fix goldsky indexer docs link

### DIFF
--- a/docs/dapp/sapphire/README.mdx
+++ b/docs/dapp/sapphire/README.mdx
@@ -105,7 +105,7 @@ dedicated RPC endpoints, consider the following providers (in alphabetic order):
 [Covalent-docs]: https://www.covalenthq.com/docs/unified-api/
 [Nexus-docs]: https://nexus.oasis.io/v1/spec/v1.html
 [Goldsky]: https://goldsky.com
-[Goldsky-docs]: https://docs.goldsky.com
+[Goldsky-docs]: https://docs.goldsky.com/subgraphs/deploying-subgraphs
 [OasisScan-Testnet-docs]: https://api.oasisscan.com/testnet/swagger-ui/#/runtime-controller
 [OasisScan-Mainnet-docs]: https://api.oasisscan.com/mainnet/swagger-ui/#/runtime-controller
 [SubQuery]: https://subquery.network


### PR DESCRIPTION
Change the link from https://docs.goldsky.com/introduction to https://docs.goldsky.com/subgraphs/deploying-subgraphs