### PR TITLE
docs: fixed broken link in /dapp/tools

### DIFF
--- a/docs/dapp/tools/README.md
+++ b/docs/dapp/tools/README.md
@@ -1,11 +1,10 @@
 # Tools & Services
 
 Oasis integrates with a number of services and provides tooling support for
-developers using [Remix] (*unencrypted transactions only*), [Sourcify],
-[Docker][localnet], and more. Please reach out to us on [Discord][discord] if
-you are using a tool that has problems integrating with Oasis.
+developers using [Remix] (*unencrypted transactions only*), [Docker][localnet],
+and more. Please reach out to us on [Discord][discord] if you are using a tool
+that has problems integrating with Oasis.
 
 [Remix]: https://remix.run/docs/en/main
-[Sourcify]: /dapp/sapphire/guide#contract-verification
 [localnet]: /dapp/sapphire/guide#running-a-private-oasis-network-locally
 [discord]: https://oasis.io/discord


### PR DESCRIPTION
Closes: #949

This requires updating the `sapphire` submodule.