### PR TITLE
Update stake-requirements.md

### DIFF
--- a/docs/node/run-your-node/prerequisites/stake-requirements.md
+++ b/docs/node/run-your-node/prerequisites/stake-requirements.md
@@ -59,7 +59,7 @@ To run a ParaTime compute node, the minimum you need to stake currently is:
 
 |            | Mainnet     | Testnet  |
 | ---------- | ----------- | -------- |
-| Sapphire   | 50,000 ROSE | 100 TEST |
+| Sapphire   | 5,000,000 ROSE | 100 TEST |
 | Emerald    | 50,000 ROSE | 100 TEST |
 | Cipher     | 100 ROSE    | 100 TEST |
 

--- a/docs/node/run-your-node/prerequisites/stake-requirements.md
+++ b/docs/node/run-your-node/prerequisites/stake-requirements.md
@@ -59,8 +59,8 @@ To run a ParaTime compute node, the minimum you need to stake currently is:
 
 |            | Mainnet     | Testnet  |
 | ---------- | ----------- | -------- |
-| Sapphire   | 5,000,000 ROSE | 100 TEST |
-| Emerald    | 50,000 ROSE | 100 TEST |
+| Sapphire   | 5,000,100 ROSE | 100 TEST |
+| Emerald    | 5,000,100 ROSE | 100 TEST |
 | Cipher     | 100 ROSE    | 100 TEST |
 
 


### PR DESCRIPTION
So in this document it shows the minimum requirement to run Mainnet Sapphire Node is to be in Active Validator Set that required to be staked at least 5,000,000 ROSE https://docs.oasis.io/get-involved/run-node/paratime-node/#mainnet-requirements But here it only shows 50,000 ROSE and doesn't talk about to be in the active validator set.

[Preview](https://deploy-preview-975--oasisprotocol-docs.netlify.app/node/run-your-node/prerequisites/stake-requirements)