### PR TITLE
docs/node/run-your-node: Add missing datadir for Cobalt archive node

### DIFF
--- a/docs/node/run-your-node/archive-node.md
+++ b/docs/node/run-your-node/archive-node.md
@@ -92,6 +92,8 @@ runtime:
 To run an archive node for Cobalt, use [Oasis Core v21.3.14] and the following configuration:
 
 ```yaml
+datadir: /node/data
+
 log:
   level:
     default: info


### PR DESCRIPTION
The archive node configuration for Cobalt was missing the `datadir`  specification at the beginning of the file.