### PR TITLE
tee: Add instructions for configuring DCAP on IBM Cloud

### DIFF
--- a/docs/node/run-your-node/prerequisites/set-up-trusted-execution-environment-tee.md
+++ b/docs/node/run-your-node/prerequisites/set-up-trusted-execution-environment-tee.md
@@ -161,12 +161,16 @@ Some cloud providers require you to use their PCCS.
 - Alibaba Cloud: See the [Alibaba Cloud documentation] for details on configuring the quote provider. The
   documentation shows the required `sgx_default_qcnl.conf` changes.
 
+- IBM Cloud: See the [IBM Cloud documentation] for details on configuring the quote provider. The
+  documentation shows the required `sgx_default_qcnl.conf` changes.
+
 - Other cloud providers: If you are using a different cloud service provider, consult their
 specific documentation for the appropriate PCCS configuration and guidance on configuring the quote provider, or
 use one of the other PCCS options.
 
 [Azure documentation]: https://learn.microsoft.com/en-us/azure/security/fundamentals/trusted-hardware-identity-management#how-do-i-use-intel-qpl-with-trusted-hardware-identity-management
 [Alibaba Cloud documentation]: https://www.alibabacloud.com/help/en/ecs/user-guide/build-an-sgx-encrypted-computing-environment
+[IBM Cloud documentation]: https://cloud.ibm.com/docs/vpc?topic=vpc-about-attestation-sgx-dcap-vpc
 
 #### Own PCCS
 

--- a/docs/node/run-your-node/prerequisites/set-up-trusted-execution-environment-tee.md
+++ b/docs/node/run-your-node/prerequisites/set-up-trusted-execution-environment-tee.md
@@ -546,6 +546,26 @@ This may be related to a bug in the Linux kernel when attempting to run enclaves
 on certain hardware configurations. Upgrading the Linux kernel to a version
 equal to or greater than 6.5.0 may solve the issue.
 
+### Unable to Launch Enclaves: Input/output error
+
+If running `sgx-detect --verbose` reports:
+
+```
+🕮 SGX system software > Able to launch enclaves > Debug mode
+The enclave could not be launched.
+
+debug: failed to load report enclave
+debug: cause: Failed to call ECREATE.
+debug: cause: I/O ctl failed.
+debug: cause: Input/output error (os error 5)
+```
+
+This may be related to a bug in the [`rust-sgx`](https://github.com/fortanix/rust-sgx/issues/565)
+library causing `sgx-detect` (and `attestation-tool`) to fail and report that
+debug enclaves cannot be launched. This is a known issue and is being worked on.
+If the `sgx-detect` is reporting that production enclaves can be launched, you
+can ignore this error when setting up the Oasis node.
+
 ### Couldn't find the platform library
 
 If AESMD service log reports:


### PR DESCRIPTION
After testing the SGX support on IBM Cloud we are adding the instructions for configuring DCAP on IBM Cloud.