### PR TITLE
Update new Oasis Scan API urls

### DIFF
--- a/docs/dapp/README.mdx
+++ b/docs/dapp/README.mdx
@@ -81,12 +81,11 @@ Public gRPC endpoints (in alphabetic order):
 
 | Name (Provider)                           | Mainnet URL                            | Testnet URL                            | Documentation                              |
 |-------------------------------------------|----------------------------------------|----------------------------------------|--------------------------------------------|
-| Oasis Scan ([Bit Cat])                    | `https://api.oasisscan.com/mainnet/v2` | `https://api.oasisscan.com/testnet/v2` | [Mainnet API][OasisScan-Mainnet-docs], [Testnet API][OasisScan-Testnet-docs] |
+| Oasis Scan ([Bit Cat])                    | `https://api.oasisscan.com/v2/mainnet` | `https://api.oasisscan.com/v2/testnet` | [API][OasisScan-docs] |
 | Oasis Nexus ([Oasis Protocol Foundation]) | `https://nexus.oasis.io/v1`            | `https://testnet.nexus.oasis.io/v1`    | [API][Nexus-docs]                          |
 
 [Nexus-docs]: https://nexus.oasis.io/v1/spec/v1.html
-[OasisScan-Testnet-docs]: https://api.oasisscan.com/testnet/swagger-ui/
-[OasisScan-Mainnet-docs]: https://api.oasisscan.com/mainnet/swagger-ui/
+[OasisScan-docs]: https://api.oasisscan.com/v2/swagger/
 
 ## Rosetta Endpoints
 

--- a/docs/dapp/cipher/README.mdx
+++ b/docs/dapp/cipher/README.mdx
@@ -88,10 +88,9 @@ the Cipher transactions using the [`oasis paratime show`] command part of the
 
 | Name (Provider)                           | Mainnet URL                                           | Testnet URL                          | Documentation     |
 |-------------------------------------------|-------------------------------------------------------|--------------------------------------|-------------------|
-| Oasis Scan ([Bit Cat])                    | `https://api.oasisscan.com/mainnet/v2`                | `https://api.oasisscan.com/testnet/v2` | [Mainnet Runtime API][OasisScan-Mainnet-docs], [Testnet Runtime API][OasisScan-Testnet-docs] |
+| Oasis Scan ([Bit Cat])                    | `https://api.oasisscan.com/v2/mainnet`                | `https://api.oasisscan.com/v2/testnet` | [Runtime API][OasisScan-docs] |
 
-[OasisScan-Testnet-docs]: https://api.oasisscan.com/testnet/swagger-ui/#/runtime-controller
-[OasisScan-Mainnet-docs]: https://api.oasisscan.com/mainnet/swagger-ui/#/runtime-controller
+[OasisScan-docs]: https://api.oasisscan.com/v2/swagger/#/runtime
 
 :::note
 

--- a/docs/dapp/cipher/network.mdx
+++ b/docs/dapp/cipher/network.mdx
@@ -49,10 +49,9 @@ Cipher transactions with the [`oasis paratime show`] command using the
 
 | Name (Provider)                           | Mainnet URL                                           | Testnet URL                          | Documentation     |
 |-------------------------------------------|-------------------------------------------------------|--------------------------------------|-------------------|
-| Oasis Scan ([Bit Cat])                    | `https://api.oasisscan.com/mainnet/v2`                | `https://api.oasisscan.com/testnet/v2` | [Mainnet Runtime API][OasisScan-Mainnet-docs], [Testnet Runtime API][OasisScan-Testnet-docs] |
+| Oasis Scan ([Bit Cat])                    | `https://api.oasisscan.com/v2/mainnet`                | `https://api.oasisscan.com/v2/testnet` | [Runtime API][OasisScan-docs] |
 
-[OasisScan-Testnet-docs]: https://api.oasisscan.com/testnet/swagger-ui/#/runtime-controller
-[OasisScan-Mainnet-docs]: https://api.oasisscan.com/mainnet/swagger-ui/#/runtime-controller
+[OasisScan-docs]: https://api.oasisscan.com/v2/swagger/#/runtime
 
 :::note
 

--- a/docs/dapp/emerald/network.mdx
+++ b/docs/dapp/emerald/network.mdx
@@ -69,14 +69,13 @@ dedicated RPC endpoints, consider the following providers (in alphabetic order):
 |-------------------------------------------|-------------------------------------------------------|--------------------------------------|-------------------|
 | [Covalent]                                | `https://api.covalenthq.com/v1/oasis-emerald-mainnet` | *N/A*                                | [Unified API docs][Covalent-docs] |
 | Oasis Nexus ([Oasis Protocol Foundation]) | `https://nexus.oasis.io/v1/`                          | `https://testnet.nexus.oasis.io/v1/` | [API][Nexus-docs] |
-| Oasis Scan ([Bit Cat])                    | `https://api.oasisscan.com/mainnet/v2`                | `https://api.oasisscan.com/testnet/v2` | [Mainnet Runtime API][OasisScan-Mainnet-docs], [Testnet Runtime API][OasisScan-Testnet-docs] |
+| Oasis Scan ([Bit Cat])                    | `https://api.oasisscan.com/v2/mainnet`                | `https://api.oasisscan.com/v2/testnet` | [Runtime API][OasisScan-docs] |
 | [SubQuery Network][SubQuery]              | *N/A*                                                 | *N/A*                                | [SubQuery Academy][SubQuery-docs], [QuickStart][SubQuery-quickstart], [Starter project][SubQuery-starter] |
 
 [Covalent]: https://www.covalenthq.com/
 [Covalent-docs]: https://www.covalenthq.com/docs/unified-api/
 [Nexus-docs]: https://nexus.oasis.io/v1/spec/v1.html
-[OasisScan-Testnet-docs]: https://api.oasisscan.com/testnet/swagger-ui/#/runtime-controller
-[OasisScan-Mainnet-docs]: https://api.oasisscan.com/mainnet/swagger-ui/#/runtime-controller
+[OasisScan-docs]: https://api.oasisscan.com/v2/swagger/#/runtime
 [SubQuery]: https://subquery.network
 [SubQuery-docs]: https://academy.subquery.network/
 [SubQuery-quickstart]: https://academy.subquery.network/quickstart/quickstart.html


### PR DESCRIPTION
Docs are referring to deprecated API that will be removed soon. PR updates Oasis Scan to v2 version which is currently used by BitCat.

Part of https://github.com/oasisprotocol/wallet/issues/2086