### PR TITLE
tooling: Specify yarn version via packageManager

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,5 +62,6 @@
   },
   "engines": {
     "node": ">=20.0"
-  }
+  },
+  "packageManager": "yarn@1.22.22"
 }


### PR DESCRIPTION
## Description

Corepack likes an explicit `packageManager`. I believe this is `1.22.22` for us for now.

Note. We could consider going up to `v4` as we are already on Node 20.