### PR TITLE
docs/build: Add Consensus Oasis Explorer links

### DIFF
--- a/docs/build/README.mdx
+++ b/docs/build/README.mdx
@@ -83,10 +83,10 @@ Public gRPC endpoints (in alphabetic order):
 
 ## Consensus Layer Block Explorers
 
-| Name (Provider)                              | Mainnet URL               | Testnet URL                   |
-|----------------------------------------------|---------------------------|-------------------------------|
-| Oasis Scan ([Bit Cat])                       | `https://www.oasisscan.com` | `https://testnet.oasisscan.com` |
-| Oasis Explorer ([Oasis Protocol Foundation]) | *Coming soon*             | *Coming soon*                 |
+| Name (Provider)                              | Mainnet URL                                   | Testnet URL                                 |
+|----------------------------------------------|-----------------------------------------------|---------------------------------------------|
+| Oasis Explorer ([Oasis Protocol Foundation]) | https://explorer.oasis.io/mainnet/consensus   | https://explorer.oasis.io/testnet/consensus |
+| Oasis Scan ([Bit Cat])                       | https://www.oasisscan.com                     | https://testnet.oasisscan.com               |
 
 [Bit Cat]: https://www.bitcat365.com/
 
@@ -94,8 +94,8 @@ Public gRPC endpoints (in alphabetic order):
 
 | Name (Provider)                           | Mainnet URL                            | Testnet URL                            | Documentation                              |
 |-------------------------------------------|----------------------------------------|----------------------------------------|--------------------------------------------|
-| Oasis Scan ([Bit Cat])                    | `https://api.oasisscan.com/v2/mainnet` | `https://api.oasisscan.com/v2/testnet` | [API][OasisScan-docs] |
 | Oasis Nexus ([Oasis Protocol Foundation]) | `https://nexus.oasis.io/v1`            | `https://testnet.nexus.oasis.io/v1`    | [API][Nexus-docs]                          |
+| Oasis Scan ([Bit Cat])                    | `https://api.oasisscan.com/v2/mainnet` | `https://api.oasisscan.com/v2/testnet` | [API][OasisScan-docs]                      |
 
 [Nexus-docs]: https://nexus.oasis.io/v1/spec/v1.html
 [OasisScan-docs]: https://api.oasisscan.com/v2/swagger/


### PR DESCRIPTION
Adding Consensus Oasis Explorer links for Mainnet and Testnet to `docs/build/README.mdx`.