### PR TITLE
docs/node/state-sync: Update Genesis document's hash for Mainnet & link Oasis Explorer

### DIFF
--- a/docs/node/run-your-node/advanced/sync-node-using-state-sync.md
+++ b/docs/node/run-your-node/advanced/sync-node-using-state-sync.md
@@ -80,15 +80,15 @@ of the following options.
 
 #### Block Explorers
 
-Browse to one of our block explorers (e.g. [Oasis Scan], [Oasis Monitor]) and
+Browse to one of our block explorers (e.g. [Oasis Explorer], [Oasis Scan]) and
 obtain the trusted height and hash there:
 
 1. Obtain the current block height from the main page, e.g. 4819139.
 2. Click on block height's number to view the block's details and obtain its
    hash, e.g. `377520acaf7b8011b95686b548504a973aa414abba2db070b6a85725dec7bd21`.
 
+[Oasis Explorer]: https://explorer.oasis.io/
 [Oasis Scan]: https://www.oasisscan.com
-[Oasis Monitor]: https://oasismonitor.com
 
 #### A Trusted Node
 

--- a/docs/node/run-your-node/advanced/sync-node-using-state-sync.md
+++ b/docs/node/run-your-node/advanced/sync-node-using-state-sync.md
@@ -124,7 +124,7 @@ the values you need are `latest_height` and `latest_hash`.
 #### Public Rosetta Gateway
 
 First obtain the network's Genesis document's hash (e.g. from the Networks Parameters Page):
-- mainnet: [b11b369e0da5bb230b220127f5e7b242d385ef8c6f54906243f30af63c815535](https://docs.oasis.io/node/mainnet/)
+- mainnet: [bb3d748def55bdfb797a2ac53ee6ee141e54cd2ab2dc2375f4a0703a178e6e55](https://docs.oasis.io/node/mainnet/)
 - testnet: [0b91b8e4e44b2003a7c5e23ddadb5e14ef5345c0ebcb3ddcae07fa2f244cab76](https://docs.oasis.io/node/testnet/)
 
 Query our public Rosetta Gateway instance and obtain the trusted height and hash


### PR DESCRIPTION
While trying out State Sync as a way to quickly bootstrap a full Oasis node, I came across two things that need updates:

- Genesis document's hash for Mainnet (use `oasis-4`/Eden upgrade), and
- linking Oasis Explorer instead of Oasis Monitor.