### PR TITLE
docs/node: Document ParaTime observer node

### DIFF
--- a/docs/node/run-your-node/README.mdx
+++ b/docs/node/run-your-node/README.mdx
@@ -53,12 +53,14 @@ efficiently.
 
 ## Client Nodes
 
-A Client Node is a type of node within the Oasis Network that serves as
+A [Client Node] is a type of node within the Oasis Network that serves as
 an interface for users or other applications to interact with the blockchain.
 Unlike compute nodes, which handle transaction processing and smart contract
 execution, client nodes are primarily responsible for tasks such as querying
 the blockchain, submitting transactions, and retrieving other data from the
-network.
+network. For confidential ParaTimes such as Sapphire and Cipher, there is a
+special mode of client node called [Observer Node] that supports confidential
+smart contact queries.
 
 - **[Non-Validator Node]** is a type of node in the Oasis Network that does not
 participate in the consensus process of validating and proposing new blocks.
@@ -84,6 +86,8 @@ to deploy and manage decentralized applications (dApps) that utilize the
 Ethereum Virtual Machine (EVM).
 
 [Non-Validator Node]: ./non-validator-node.mdx
+[Client Node]: ./paratime-client-node.mdx
+[Observer Node]: ./paratime-observer-node.mdx
 [Sapphire Client Node]: ./paratime-client-node.mdx
 [Cipher Client Node]: ./paratime-client-node.mdx
 [Emerald Client Node]: ./paratime-client-node.mdx

--- a/docs/node/run-your-node/paratime-client-node.mdx
+++ b/docs/node/run-your-node/paratime-client-node.mdx
@@ -7,7 +7,7 @@ import TabItem from '@theme/TabItem';
 
 :::info
 
-These instructions are for setting up a _ParaTime client_ node which only observes ParaTime activity and can submit transactions. If you want to run a _ParaTime_ node instead, see the [instructions for running a ParaTime node](paratime-node.mdx). Similarly, if you want to run a _validator_ or a _non-validator_ node instead, see the [instructions for running a validator node](validator-node.mdx) or [instructions for running a non-validator node](non-validator-node.mdx).
+These instructions are for setting up a _ParaTime client_ node which only observes ParaTime activity and can submit transactions. Check out [instructions for running a ParaTime observer node](paratime-observer-node.mdx) for running _ParaTime observer_ node if you want to support confidential queries. If you want to run a _ParaTime_ node instead, see the [instructions for running a ParaTime node](paratime-node.mdx). Similarly, if you want to run a _validator_ or a _non-validator_ node instead, see the [instructions for running a validator node](validator-node.mdx) or [instructions for running a non-validator node](non-validator-node.mdx).
 
 :::
 

--- a/docs/node/run-your-node/paratime-observer-node.mdx
+++ b/docs/node/run-your-node/paratime-observer-node.mdx
@@ -5,8 +5,8 @@ import {findSidebarItem} from '@site/src/sidebarUtils';
 
 :::info
 
-These instructions are for setting up a _ParaTime observer_ node, which observes ParaTime activity and can issue
-queries that can access confidential data. If you just want to run a _ParaTime client_ node, see the
+These instructions are for setting up a _ParaTime observer_ node, which is a special client node that supports
+confidential smart contact queries. If you just want to run a _ParaTime client_ node, see the
 [instructions for running a ParaTime client node](paratime-client-node.mdx). If you want to run a _ParaTime_ node
 instead, see the [instructions for running a ParaTime node](paratime-node.mdx). Similarly, if you want to run a
 _validator_ or a _non-validator_ node instead, see the [instructions for running a validator node](validator-node.mdx)
@@ -16,33 +16,41 @@ or [instructions for running a non-validator node](non-validator-node.mdx).
 
 :::tip
 
-The observer node role allows any ParaTime client node with appropriate TEE support to run confidential transactions
-and view calls on Sapphire ParaTime. Observer nodes are client nodes that are registered on chain so that their
-eligibility can be enforced by an on-chain policy (e.g. key manager committees can grant them permissions).
+[TEE support] and a ParaTime client node with a confidential ParaTime is required to run a ParaTime observer node.
+
+:::
+
+:::tip
+
+There may be per-ParaTime on-chain policy requirements (such as whitelisting) for running observer nodes.
 
 :::
 
 This guide will cover setting up your ParaTime observer node for the Oasis Network. Observer nodes are ParaTime
-client nodes that support confidential queries without being elected into the compute committee. This guide assumes
-some basic knowledge on the use of command line tools.
+client nodes that support confidential queries without being elected into the compute committee. They are registered on
+chain so that their eligibility can be enforced by an on-chain policy (e.g. key manager committees can grant them
+permissions). This way users can, for example, run confidential transactions and view calls on [Sapphire] ParaTime.
+This guide assumes some basic knowledge on the use of command line tools.
+
+[Sapphire]: ../../build/sapphire/README.mdx
 
 ## Prerequisites
 
 Before following this guide, make sure you've followed the [Prerequisites](prerequisites),
 [Run a Non-validator Node](non-validator-node.mdx), and [Run a ParaTime client Node](paratime-client-node.mdx)
-sections and have a working ParaTime client node with Intel SGX support.
+sections and have a working ParaTime client node with [TEE support].
 
 ### Stake Requirements
 
 To be able to register as a ParaTime observer node on the Oasis Network, you need to have enough tokens staked in your
 entity's escrow account.
 
-Current minimum staking requirements for a specific ParaTime are listed on the [Stake Requirements] page. Should you
-want to check the staking requirements for other node roles and registered ParaTimes manually, use the Oasis CLI tools
-as described in [Common Staking Info].
+Current minimum staking requirements for a specific ParaTime are listed on the [Stake Requirements] page. You can also
+use [Oasis CLI tools] to check that as described in [Common Staking Info].
 
-Finally, to stake the tokens, use our [Oasis CLI tools]. If everything was set up correctly, you should see something
-like below when running [`oasis account show`] command for your entity's account (this is an example for Testnet):
+Finally, to stake the tokens and to check if you staked correctly, you can use any wallet and any explorer. If using
+our [Oasis CLI tools] and if everything was set up correctly, you should see something like below when running
+[`oasis account show`] command for your entity's account (this is an example for Testnet):
 
 ![code shell](../../../external/cli/examples/account/show-delegations.in.static)
 
@@ -52,20 +60,19 @@ like below when running [`oasis account show`] command for your entity's account
 
 The stake requirements may differ from ParaTime to ParaTime and are subject to change in the future.
 
-:::
-
-:::info
-
-For example, if you want to register an observer node for Testnet/Mainnet, you currently need to have at least
-**200 TEST/ROSE** tokens delegated:
+Currently, for example, if you want to register an observer node for Testnet/Mainnet, you currently need to have at
+least **200 TEST/ROSE** tokens delegated:
 - **100 TEST/ROSE** for registering a new node entity and,
 - **100 TEST/ROSE** for each observer node.
+
+See the [Stake Requirements] page for more details.
 
 :::
 
 [Stake Requirements]: prerequisites/stake-requirements.md
 [Run a ParaTime Node]: ../../get-involved/run-node/paratime-node.mdx
 [Common Staking Info]: ../../general/manage-tokens/cli/network.md#show-native-token
+[TEE support]: prerequisites/set-up-trusted-execution-environment-tee.md
 [Oasis CLI tools]: ../../general/manage-tokens/cli/account.md#delegate
 [`oasis account show`]: ../../general/manage-tokens/cli/account.md#show
 
@@ -79,8 +86,8 @@ Everything in this section should be done on the `localhost` as there are sensit
 
 :::danger
 
-If you plan to run an observer node for Mainnet and Testnet make sure you create and use two separate entities
-to prevent replay attacks.
+If you plan to run an observer node for Mainnet and Testnet make sure you create and use two separate entities to
+prevent replay attacks.
 
 :::
 
@@ -105,12 +112,6 @@ to prevent replay attacks.
    ```
 
 6. Once the registration is complete, please share the Entity IDs with us so that we can whitelist them accordingly.
-
-:::tip
-
-There may be per-ParaTime on-chain policy requirements for running observer nodes.
-
-:::
 
 [Initialize Entity]: validator-node.mdx#initialize-entity
 [Starting the Oasis Node]: validator-node.mdx#starting-the-oasis-node

--- a/docs/node/run-your-node/paratime-observer-node.mdx
+++ b/docs/node/run-your-node/paratime-observer-node.mdx
@@ -1,0 +1,144 @@
+import DocCard from '@theme/DocCard';
+import {findSidebarItem} from '@site/src/sidebarUtils';
+
+# ParaTime Observer Node
+
+:::info
+
+These instructions are for setting up a _ParaTime observer_ node, which observes ParaTime activity and can issue
+queries that can access confidential data. If you just want to run a _ParaTime client_ node, see the
+[instructions for running a ParaTime client node](paratime-client-node.mdx). If you want to run a _ParaTime_ node
+instead, see the [instructions for running a ParaTime node](paratime-node.mdx). Similarly, if you want to run a
+_validator_ or a _non-validator_ node instead, see the [instructions for running a validator node](validator-node.mdx)
+or [instructions for running a non-validator node](non-validator-node.mdx).
+
+:::
+
+:::tip
+
+The observer node role allows any ParaTime client node with appropriate TEE support to run confidential transactions
+and view calls on Sapphire ParaTime. Observer nodes are client nodes that are registered on chain so that their
+eligibility can be enforced by an on-chain policy (e.g. key manager committees can grant them permissions).
+
+:::
+
+This guide will cover setting up your ParaTime observer node for the Oasis Network. Observer nodes are ParaTime
+client nodes that support confidential queries without being elected into the compute committee. This guide assumes
+some basic knowledge on the use of command line tools.
+
+## Prerequisites
+
+Before following this guide, make sure you've followed the [Prerequisites](prerequisites),
+[Run a Non-validator Node](non-validator-node.mdx), and [Run a ParaTime client Node](paratime-client-node.mdx)
+sections and have a working ParaTime client node with Intel SGX support.
+
+### Stake Requirements
+
+To be able to register as a ParaTime observer node on the Oasis Network, you need to have enough tokens staked in your
+entity's escrow account.
+
+Current minimum staking requirements for a specific ParaTime are listed on the [Stake Requirements] page. Should you
+want to check the staking requirements for other node roles and registered ParaTimes manually, use the Oasis CLI tools
+as described in [Common Staking Info].
+
+Finally, to stake the tokens, use our [Oasis CLI tools]. If everything was set up correctly, you should see something
+like below when running [`oasis account show`] command for your entity's account (this is an example for Testnet):
+
+![code shell](../../../external/cli/examples/account/show-delegations.in.static)
+
+![code](../../../external/cli/examples/account/show-delegations.out.static)
+
+:::caution
+
+The stake requirements may differ from ParaTime to ParaTime and are subject to change in the future.
+
+:::
+
+:::info
+
+For example, if you want to register an observer node for Testnet/Mainnet, you currently need to have at least
+**200 TEST/ROSE** tokens delegated:
+- **100 TEST/ROSE** for registering a new node entity and,
+- **100 TEST/ROSE** for each observer node.
+
+:::
+
+[Stake Requirements]: prerequisites/stake-requirements.md
+[Run a ParaTime Node]: ../../get-involved/run-node/paratime-node.mdx
+[Common Staking Info]: ../../general/manage-tokens/cli/network.md#show-native-token
+[Oasis CLI tools]: ../../general/manage-tokens/cli/account.md#delegate
+[`oasis account show`]: ../../general/manage-tokens/cli/account.md#show
+
+### Register a New Entity or Update Your Entity Registration
+
+:::danger
+
+Everything in this section should be done on the `localhost` as there are sensitive items that will be created.
+
+:::
+
+:::danger
+
+If you plan to run an observer node for Mainnet and Testnet make sure you create and use two separate entities
+to prevent replay attacks.
+
+:::
+
+1. If you don't have an entity yet, create a new one by following the [Initialize Entity] instructions for validators.
+
+2. If you will be running the ParaTime on a new Oasis node, also initialize a new node by following the
+   [Starting the Oasis Node] instructions for validators.
+
+3. Now, [list your node ID] in the entity descriptor file `nodes` field.
+
+4. [Register] the updated entity descriptor.
+
+5. By adding the created entity ID in the node config file, you will [configure the node] to automatically register for
+   the roles it has enabled (i.e. observer role) via the `registration.entity_id` configuration flag. No manual node
+   registration is necessary.
+
+   ```yaml
+   mode: client
+   # ... sections not relevant are omitted ...
+   registration:
+     entity_id: {{ entity_id }}
+   ```
+
+6. Once the registration is complete, please share the Entity IDs with us so that we can whitelist them accordingly.
+
+:::tip
+
+There may be per-ParaTime on-chain policy requirements for running observer nodes.
+
+:::
+
+[Initialize Entity]: validator-node.mdx#initialize-entity
+[Starting the Oasis Node]: validator-node.mdx#starting-the-oasis-node
+[list your node ID]: validator-node.mdx#add-your-node-id-to-the-entity-descriptor
+[Register]: validator-node.mdx#entity-registration
+[`oasis account withdraw`]: ../../general/manage-tokens/cli/account.md#withdraw
+[configure the node]: paratime-node.mdx#configuration
+
+## (Re)starting the Oasis Node
+
+You can (re)start the node by running the following command:
+
+```bash
+oasis-node --config /node/etc/config.yml
+```
+
+After one epoch the node should register as observer (assuming it satisfies per-ParaTime policy requirements).
+
+## Checking Node Status
+
+To ensure that your node has the observer node, you can run the following command after the node has started:
+
+```bash
+oasis-node control status -a unix:/node/data/internal.sock
+```
+
+You should see `"observer"` in the `.registration.descriptor.roles` output entry.
+
+## See also
+
+<DocCard item={findSidebarItem('/node/web3')} />

--- a/docs/node/run-your-node/prerequisites/stake-requirements.md
+++ b/docs/node/run-your-node/prerequisites/stake-requirements.md
@@ -56,7 +56,7 @@ want to set up a working node from scratch.
 | [Validator node]       | 1. Registration of entity<br/>2. Registration of the validator node<br/>3. Member of the validator set                                                               |
 | [Non-validator node]   | /                                                                                                                                                                    |
 | [ParaTime node]        | 1. Registration of entity<br/>2. Registration of the compute node<br/>3. Extra ParaTime-specific compute node stake<br/>4. Member of the validator set (Mainnet only) |
-| [ParaTime client node] | 1. Registration of entity<br/>2. Registration of the [ParaTime observer node]                                                                                                   |
+| [ParaTime observer node] | 1. Registration of entity<br/>2. Registration of the observer node |                                                                                                 |
 
 [Validator node]: ../validator-node.mdx
 [Non-validator node]: ../non-validator-node.mdx

--- a/docs/node/run-your-node/prerequisites/stake-requirements.md
+++ b/docs/node/run-your-node/prerequisites/stake-requirements.md
@@ -56,12 +56,13 @@ want to set up a working node from scratch.
 | [Validator node]       | 1. Registration of entity<br/>2. Registration of the validator node<br/>3. Member of the validator set                                                               |
 | [Non-validator node]   | /                                                                                                                                                                    |
 | [ParaTime node]        | 1. Registration of entity<br/>2. Registration of the compute node<br/>3. Extra ParaTime-specific compute node stake<br/>4. Member of the validator set (Mainnet only) |
-| [ParaTime client node] | 1. Registration of entity<br/>2. Registration of the observer node                                                                                                   |
+| [ParaTime client node] | 1. Registration of entity<br/>2. Registration of the [ParaTime observer node]                                                                                                   |
 
 [Validator node]: ../validator-node.mdx
 [Non-validator node]: ../non-validator-node.mdx
 [ParaTime node]: ../paratime-node.mdx
 [ParaTime client node]: ../paratime-client-node.mdx
+[ParaTime observer node]: ../paratime-observer-node.mdx
 
 [Oasis Explorer]: https://explorer.oasis.io/mainnet/consensus
 [Oasis Scan]: https://www.oasisscan.com

--- a/sidebarNode.ts
+++ b/sidebarNode.ts
@@ -78,7 +78,17 @@ export const sidebarNode: SidebarsConfig = {
         'node/run-your-node/seed-node',
         'node/run-your-node/archive-node',
         'node/run-your-node/paratime-node',
-        'node/run-your-node/paratime-client-node',
+        {
+          type: 'category',
+          label: 'ParaTime Client Node',
+          link: {
+            type: 'doc',
+            id: 'node/run-your-node/paratime-client-node',
+          },
+          items: [
+            'node/run-your-node/paratime-observer-node',
+          ],
+        },
         {
           type: 'category',
           label: 'Key Manager Node',


### PR DESCRIPTION
Documenting ParaTime observer node as a special type of ParaTime client node that is registered on chain and supports running confidential queries and view calls on confidential ParaTime such as Sapphire.