### PR TITLE
Fix buildwarnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,5 +64,8 @@
   "engines": {
     "node": ">=20.0"
   },
-  "packageManager": "yarn@1.22.22"
+  "packageManager": "yarn@1.22.22",
+  "resolutions": {
+    "image-size": "~1.0.2"
+  }
 }


### PR DESCRIPTION
This takes care of some of the warning saying svg files are unsupported during the build

Reference for solution: https://github.com/facebook/docusaurus/issues/9715