### PR TITLE
Add fixes for Hyperlane ping pong documentation

### DIFF
--- a/docs/build/opl/hyperlane/cli.md
+++ b/docs/build/opl/hyperlane/cli.md
@@ -7,21 +7,30 @@ description: Hyperlane CLI for Sapphire
 :::info
 
 The standard **Hyperlane CLI** relies on the `eth_getStorageAt` method,
-which is incompatible with **Sapphire** by default. To address this, use the
-**[custom branch]** of the Hyperlane CLI or follow the guidance in the
-[Troubleshooting section] of Hyperlane.
+which is incompatible with **Sapphire** by default. 
+
+To address this, the installation instructions below cherry pick the commit that fixes this issue from the use the
+**[`pb/storage-workaround`]** of the Hyperlane CLI.
 
 For more details about `eth_getStorageAt` on Sapphire, refer to the
 [Sapphire documentation].
+
+For more helps, see the [Troubleshooting section] of the Hyperlane docs.
 
 :::
 
 ## Installation
 
+Run the command below to clone the latest version of the Hyperlane relayer and apply the commit on top that fixes the `eth_getStorageAt` issue.
+
 1. Clone the Sapphire-compatible branch:
     ```bash
-    git clone https://github.com/hyperlane-xyz/hyperlane-monorepo.git --branch pb/storage-workaround
+    git clone https://github.com/hyperlane-xyz/hyperlane-monorepo.git 
     cd hyperlane-monorepo
+    git fetch
+    git pull
+    gco -b my-local-relayer
+    git cherry-pick 871df7a
     ```
 
 2. Install dependencies and build the project:
@@ -41,7 +50,8 @@ yarn workspace @hyperlane-xyz/cli hyperlane
 For guidance on how to use the modified CLI for deploying the Hyperlane Core
 on Sapphire, refer to the [official deploy documentation][hyperlane-deploy].
 
-[custom branch]: https://github.com/hyperlane-xyz/hyperlane-monorepo/tree/pb/storage-workaround
-[Sapphire documentation]: https://github.com/oasisprotocol/sapphire-paratime/blob/main/docs/develop/deployment#caution-against-using-eth_getstorageat
+[`pb/storage-workaround`]: https://github.com/hyperlane-xyz/hyperlane-monorepo/tree/pb/storage-workaround
+[Sapphire documentation]: https://docs.oasis.io/build/sapphire/ethereum#encrypted-contract-state
 [Troubleshooting section]: https://docs.hyperlane.xyz/docs/deploy-hyperlane-troubleshooting#eth_getstorageat-compatibility
 [hyperlane-deploy]: https://docs.hyperlane.xyz/docs/deploy-hyperlane
+

--- a/docs/build/opl/hyperlane/pingpong-example.md
+++ b/docs/build/opl/hyperlane/pingpong-example.md
@@ -464,7 +464,7 @@ or use the scripts below.
       // deployed mailbox on Sapphire Testnet
       const mailbox = "0x79d3ECb26619B968A68CE9337DfE016aeA471435";
 
-      const PongFactory = await hre.ethers.getContractFactory("Pong");    
+      const PongFactory = await ethers.getContractFactory("Pong");    
       const pong = await PongFactory.deploy(mailbox);
       const pongAddr = await pong.waitForDeployment();
       console.log(`Pong deployed at: ${pongAddr.target}`);
@@ -667,8 +667,8 @@ use the following script:
       console.log("Calculating fee...");
       let fee = await contract.quoteDispatch(
           destChainId,
-          hre.ethers.toUtf8Bytes(message));
-      console.log(`Fee: ${hre.ethers.formatEther(fee)} ETH`);
+          ethers.toUtf8Bytes(message));
+      console.log(`Fee: ${ethers.formatEther(fee)} ETH`);
       console.log("Sending message...");
       const tx = await contract.sendPing(destChainId, message, {value: fee});
       await tx.wait();

--- a/docs/build/opl/hyperlane/pingpong-example.md
+++ b/docs/build/opl/hyperlane/pingpong-example.md
@@ -92,7 +92,13 @@ Testnet.
  const accounts = process.env.PRIVATE_KEY ? [process.env.PRIVATE_KEY] : [];
 
  const config: HardhatUserConfig = {
-  solidity: "0.8.24",
+    // Sapphire only supports evmVersion `paris`
+    solidity: {
+      version: "0.8.28",
+      settings: {
+        evmVersion: "paris",
+      }
+    },
   // highlight-start
   networks: {
     'arbitrum-sepolia': {
@@ -111,15 +117,6 @@ Testnet.
 
  export default config;
 ```
-
-:::info
-
-Sapphire only supports evmVersion `paris`, which is the current default for
-Hardhat. Should Hardhat change this, you need to add `evmVersion: "paris"` to
-the solidity config.
-
-:::
-
 
 ### Ping Pong Contract
 

--- a/docs/build/opl/hyperlane/relayer.md
+++ b/docs/build/opl/hyperlane/relayer.md
@@ -7,6 +7,7 @@ description: Run a Hyperlane Relayer
 
 [relayer]: https://docs.hyperlane.xyz/docs/protocol/agents/relayer
 
+
 ## Run a Relayer
 
 The easiest way to run a relayer is with the **[Hyperlane CLI]**.
@@ -18,11 +19,22 @@ The easiest way to run a relayer is with the **[Hyperlane CLI]**.
     ```shell
     export HYP_KEY='<YOUR_PRIVATE_KEY>'
     ```
+
+:::info
+
+Make sure that the address behind the `HYP_KEY` has enough native tokens on both networks, so that it can relays messages.
+
+:::
+
+
 2. Start a relayer which watches `Arbitrum Sepolia` & `SapphireTestnet`
 
     ```shell
-    hyperlane relayer --chains sapphiretestnet,arbitrumsepolia
+    yarn workspace @hyperlane-xyz/cli hyperlane relayer \
+      --chains sapphiretestnet,arbitrumsepolia \
+      --verbosity debug
     ```
+
 
 :::info Chain Configs
 


### PR DESCRIPTION
# What does this PR introduce?

This PR fixes few bug fixes not working in the ping pong example for Hyperlane.

It also improve the command on how to run a Hyperlane relayer

- remove mention of EVM version `paris` and adapt `hardhat.config.ts` file to use it instead
- remove mention of `hre` in scripts that access `hre.ethers` (use `ethers` directly instead).
- improve process to run Hyperlane relayer with latest changes