### PR TITLE
external/oasis-core: Pin to master

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,6 @@
 [submodule "external/oasis-core"]
 	path = external/oasis-core
 	url = https://github.com/oasisprotocol/oasis-core
-	branch = stable/24.2.x
 [submodule "external/oasis-sdk"]
 	path = external/oasis-sdk
 	url = https://github.com/oasisprotocol/oasis-sdk


### PR DESCRIPTION
When merging https://github.com/oasisprotocol/oasis-core/pull/6213 I realized the docs dependabot doesn't want to update the oasis-core external module, because we have it pinned to an ancient v24.2.x.

Instead of bumping the oasis-core repo version each time a new release is made, let's simply have the master branch referenced, and let dependabot follow the latest changes. If any chapters disappear from the core repo (unlikely though), the docs linter will still catch it.