### PR TITLE
Admonition Cards new styling

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -51,6 +51,10 @@ const config: Config = {
           routeBasePath: '/',
           showLastUpdateTime: true,
           sidebarPath: './sidebars.ts',
+          admonitions: {
+            keywords: ['example'],
+            extendDefaults: true,
+          },
         },
         blog: false,
         theme: {

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -33,6 +33,8 @@
   --ifm-info-background: #EFF6FF;
   --ifm-tip-foreground: #059669;
   --ifm-tip-background: #F0FDF4;
+  --ifm-example-foreground: #F59E0B;
+  --ifm-example-background: #FEFCE8;
 }
 
 /* For readability concerns, you should choose a lighter palette in dark mode. */
@@ -58,6 +60,8 @@ html[data-theme='dark'] {
   --ifm-info-background: #082F49;
   --ifm-tip-foreground: #34D399;
   --ifm-tip-background: #052E16;
+  --ifm-example-foreground: #FEF08A;
+  --ifm-example-background: #51430E;
 }
 
 /* Custom fonts */
@@ -282,4 +286,21 @@ html[data-theme="dark"] {
 
 .theme-admonition-tip svg{
   fill: var(--ifm-tip-foreground)!important;
+}
+
+.theme-admonition-example{
+  background-color: var(--ifm-example-background);
+  border: 1px solid var(--ifm-example-foreground);
+}
+
+.theme-admonition-example, .theme-admonition-example a{
+  color: var(--ifm-example-foreground);
+}
+
+.theme-admonition-example svg{
+  fill: transparent!important;
+}
+
+.theme-admonition-example p{
+  margin-bottom: 0;
 }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -23,6 +23,16 @@
   --ifm-color-secondary-text: #71717A;
   --ifm-color-card-heading: #09090B;
   --ifm-color-card-heading-secondary: #18181B;
+  --ifm-alert-foreground: #EF4444;
+  --ifm-alert-background: #FEF2F2;
+  --ifm-note-foreground: #71717A;
+  --ifm-note-background: #F4F4F5;
+  --ifm-caution-foreground: #FB923C;
+  --ifm-caution-background: #FFF7ED;
+  --ifm-info-foreground: #3B82F6;
+  --ifm-info-background: #EFF6FF;
+  --ifm-tip-foreground: #059669;
+  --ifm-tip-background: #F0FDF4;
 }
 
 /* For readability concerns, you should choose a lighter palette in dark mode. */
@@ -38,6 +48,16 @@ html[data-theme='dark'] {
   --ifm-color-secondary-text: #A1A1AA;
   --ifm-color-card-heading: #FAFAFA;
   --ifm-color-card-heading-secondary: #FAFAFA;
+  --ifm-alert-foreground: #FEE2E2;
+  --ifm-alert-background: #431407;
+  --ifm-note-foreground: #A1A1AA;
+  --ifm-note-background: #27272A;
+  --ifm-caution-foreground: #FB923C;
+  --ifm-caution-background: #422006;
+  --ifm-info-foreground: #BFDBFE;
+  --ifm-info-background: #082F49;
+  --ifm-tip-foreground: #34D399;
+  --ifm-tip-background: #052E16;
 }
 
 /* Custom fonts */
@@ -194,3 +214,72 @@ html[data-theme="dark"] {
   display: none;
 }
 
+/* Admonition cards styling */
+.theme-admonition{
+  border-radius: 6px;
+}
+
+.theme-admonition-danger{
+  background-color: var(--ifm-alert-background)!important;
+  border: 1px solid var(--ifm-alert-foreground);
+}
+
+.theme-admonition-danger, .theme-admonition-danger a{
+  color: var(--ifm-alert-foreground);
+}
+
+.theme-admonition-danger svg{
+  fill: var(--ifm-alert-foreground)!important;
+}
+
+.theme-admonition-note{
+  background-color: var(--ifm-note-background);
+  border: 1px solid var(--ifm-note-foreground);
+}
+
+.theme-admonition-note, .theme-admonition-note a{
+  color: var(--ifm-note-foreground);
+}
+
+.theme-admonition-note svg{
+  fill: var(--ifm-note-foreground)!important;
+}
+
+.theme-admonition-caution{
+  background-color: var(--ifm-caution-background);
+  border: 1px solid var(--ifm-caution-foreground);
+}
+
+.theme-admonition-caution, .theme-admonition-caution a{
+  color: var(--ifm-caution-foreground);
+}
+
+.theme-admonition-caution svg{
+  fill: var(--ifm-caution-foreground)!important;
+}
+
+.theme-admonition-info{
+  background-color: var(--ifm-info-background);
+  border: 1px solid var(--ifm-info-foreground);
+}
+
+.theme-admonition-info, .theme-admonition-info a{
+  color: var(--ifm-info-foreground);
+}
+
+.theme-admonition-info svg{
+  fill: var(--ifm-info-foreground)!important;
+}
+
+.theme-admonition-tip{
+  background-color: var(--ifm-tip-background);
+  border: 1px solid var(--ifm-tip-foreground);
+}
+
+.theme-admonition-tip, .theme-admonition-tip a{
+  color: var(--ifm-tip-foreground);
+}
+
+.theme-admonition-tip svg{
+  fill: var(--ifm-tip-foreground)!important;
+}

--- a/src/theme/Admonition/Types.tsx
+++ b/src/theme/Admonition/Types.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import DefaultAdmonitionTypes from '@theme-original/Admonition/Types';
+
+function ExampleAdmonition(props: any) {
+  return (
+    <div className="theme-admonition theme-admonition-example alert alert--example" style={{ marginBottom: '1rem' }}>
+      <div style={{display: 'flex', textTransform: 'uppercase', alignItems: 'center', gap: '0.4rem', marginBottom: '0.3rem'}}>
+        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="transparent">
+            <path d="M15.0002 12L6.62718 20.373C6.22935 20.7708 5.68979 20.9943 5.12718 20.9943C4.56457 20.9943 4.025 20.7708 3.62718 20.373C3.22936 19.9752 3.00586 19.4356 3.00586 18.873C3.00586 18.3104 3.22936 17.7708 3.62718 17.373L12.0002 9M18 15L22 11M21.5 11.5L19.586 9.58596C19.2109 9.21098 19.0001 8.70235 19 8.17196V6.99996L16.74 4.73996C15.6245 3.62515 14.115 2.99432 12.538 2.98396L9 2.95996L9.92 3.77996C10.5735 4.35935 11.0967 5.07066 11.4552 5.867C11.8137 6.66335 11.9994 7.52663 12 8.39996V9.99996L14 12H15.172C15.7024 12.0001 16.211 12.2109 16.586 12.586L18.5 14.5" 
+                stroke="currentColor" 
+                stroke-width="2" 
+                stroke-linecap="round" 
+                stroke-linejoin="round"
+            />
+        </svg>
+        <h5 style={{marginBottom: '0'}}>{props.title}</h5>
+      </div>
+      <div>{props.children}</div>
+    </div>
+  );
+}
+
+const AdmonitionTypes = {
+  ...DefaultAdmonitionTypes,
+  example: ExampleAdmonition,
+};
+
+export default AdmonitionTypes;


### PR DESCRIPTION
Implementation of new styling of admonition cards and create a new instance for 'Example'.

Before:
<img width="1031" height="374" alt="Screenshot 2025-07-24 at 16 48 13" src="https://github.com/user-attachments/assets/cfd4472f-aa0f-47ce-8a99-9aafd1c84903" />
<img width="1004" height="354" alt="Screenshot 2025-07-24 at 16 53 51" src="https://github.com/user-attachments/assets/d1f28189-0363-4277-a1e5-9c3b3a2332c3" />
<img width="1036" height="847" alt="Screenshot 2025-07-24 at 16 54 54" src="https://github.com/user-attachments/assets/4e12c75a-af70-483e-aec0-e895e17445fb" />
<img width="1006" height="243" alt="Screenshot 2025-07-24 at 16 56 18" src="https://github.com/user-attachments/assets/1e5e9d09-0018-48ea-b59f-d50139ffde7b" />

After:
<img width="1013" height="364" alt="Screenshot 2025-07-24 at 16 53 24" src="https://github.com/user-attachments/assets/4d9e3d13-2ee1-41e6-affd-32244331b06f" />
<img width="1005" height="351" alt="Screenshot 2025-07-24 at 16 53 38" src="https://github.com/user-attachments/assets/144ef035-ed8d-467b-bfb3-ecc7f30d0005" />
<img width="1038" height="804" alt="Screenshot 2025-07-24 at 16 55 33" src="https://github.com/user-attachments/assets/c19ac9af-3448-4732-aa72-90181f30f815" />
<img width="1028" height="242" alt="Screenshot 2025-07-24 at 16 56 00" src="https://github.com/user-attachments/assets/203bbd42-fe83-4643-ae5a-ef3c1d4312f4" />

