### PR TITLE
docs: Fix state sync documentation

### DIFF
--- a/docs/node/run-your-node/advanced/sync-node-using-state-sync.md
+++ b/docs/node/run-your-node/advanced/sync-node-using-state-sync.md
@@ -172,8 +172,8 @@ the values you need are `latest_height` and `latest_hash`.
 #### Public Rosetta Gateway
 
 First obtain the network's Genesis document's hash (e.g. from the Networks Parameters Page):
-- mainnet: [bb3d748def55bdfb797a2ac53ee6ee141e54cd2ab2dc2375f4a0703a178e6e55](https://docs.oasis.io/node/mainnet/)
-- testnet: [0b91b8e4e44b2003a7c5e23ddadb5e14ef5345c0ebcb3ddcae07fa2f244cab76](https://docs.oasis.io/node/testnet/)
+- [Mainnet](https://docs.oasis.io/node/mainnet/): `bb3d748def55bdfb797a2ac53ee6ee141e54cd2ab2dc2375f4a0703a178e6e55`
+- [Testnet](https://docs.oasis.io/node/testnet/): `0b91b8e4e44b2003a7c5e23ddadb5e14ef5345c0ebcb3ddcae07fa2f244cab76`
 
 Query our public Rosetta Gateway instance and obtain the latest height by
 replacing the `<chain-context>` with the value obtained in the previous step:

--- a/docs/node/run-your-node/advanced/sync-node-using-state-sync.md
+++ b/docs/node/run-your-node/advanced/sync-node-using-state-sync.md
@@ -2,12 +2,11 @@
 
 The State Sync is a way to **quickly bootstrap** a **full Oasis node** (either a
 [validator node](../validator-node.mdx) or a
-[non-validator node](../non-validator-node.mdx)) by using the
-[CometBFT's Light Client protocol]. It allows one to initialize a node from a
-trusted height, its corresponding block's header and a trusted validator set
-(given in the [genesis document](../../genesis-doc.md)). It does so by securely
-updating the node's trusted state by requesting and verifying a minimal set of
-data from the network's full nodes.
+[non-validator node](../non-validator-node.mdx)) by initializing it from the
+trusted block's header, identified by the trusted height and hash. The node's
+trusted state is then securely updated by requesting and verifying a minimal set of
+data (checkpoints metadata and chunks) from the P2P network. Internally, it uses
+[CometBFT's Light Client protocol] and Merkle proofs to filter out invalid data.
 
 :::info
 


### PR DESCRIPTION
Document how to set correct trusted height and hash for the state sync so that they point to sufficiently old block header, to ensure there are available checkpoints. 




