### PR TITLE
Details card and admonition warning card styling

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -224,7 +224,8 @@ html[data-theme="dark"] {
 }
 
 /* Admonition cards styling */
-.theme-admonition{
+.theme-admonition,
+.alert{
   border-radius: 6px;
 }
 
@@ -254,15 +255,18 @@ html[data-theme="dark"] {
   fill: var(--ifm-note-foreground)!important;
 }
 
-.theme-admonition-caution{
+.theme-admonition-caution,
+.theme-admonition-warning{
   background-color: var(--ifm-caution-background);
   border: 1px solid var(--ifm-caution-foreground);
 }
 
+.theme-admonition-warning, .theme-admonition-warning a,
 .theme-admonition-caution, .theme-admonition-caution a{
   color: var(--ifm-caution-foreground);
 }
 
+.theme-admonition-warning svg,
 .theme-admonition-caution svg{
   fill: var(--ifm-caution-foreground)!important;
 }


### PR DESCRIPTION
Add rounded corners to details cards and include admonition-warning styling. Issue [#1377](https://github.com/oasisprotocol/docs/issues/1377).

Before:
<img width="776" height="162" alt="Screenshot 2025-08-05 at 12 20 04" src="https://github.com/user-attachments/assets/f4bb6bcc-d546-452a-9dce-695c779b8f87" />
<img width="787" height="178" alt="Screenshot 2025-08-05 at 12 20 17" src="https://github.com/user-attachments/assets/3aaeb79b-8589-41e8-a25a-209c7e709ffa" />

After:
<img width="785" height="159" alt="Screenshot 2025-08-05 at 12 18 10" src="https://github.com/user-attachments/assets/e9f697eb-24b3-44d5-afcc-b1aae0f7ee59" />
<img width="784" height="168" alt="Screenshot 2025-08-05 at 12 20 38" src="https://github.com/user-attachments/assets/d940f6e9-bc34-44a3-b4e4-c572dd583932" />
