### PR TITLE
Change all headings font to Inter Variable

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -15,7 +15,7 @@
   --ifm-color-primary-lighter: #0500e1;
   --ifm-color-primary-lightest: #0500e1;
   --ifm-code-font-size: 95%;
-  --ifm-font-family-base: 'Inter', sans-serif;
+  --ifm-font-family-base: "Inter Variable", sans-serif;
   --ifm-font-family-monospace: "Roboto Mono", monospace;
   --ifm-global-radius: 0;
   --ifm-alert-border-width: 5px;
@@ -80,8 +80,14 @@ html[data-theme='dark'] {
   src: url("/static/fonts/RobotoMono-Regular.ttf") format("truetype");
 }
 
-article strong, h1 {
-  font-family: "Roboto Medium", sans-serif;
+h1, h2, h3, h4, h5, h6 {
+  font-family: "Inter Variable", sans-serif;
+  letter-spacing: -0.04em;
+  font-weight: 600;
+}
+
+article strong {
+  font-family: "Inter Variable", sans-serif;
 }
 
 .docusaurus-highlight-code-line {


### PR DESCRIPTION
Implements Issue [#1368](https://github.com/oasisprotocol/docs/issues/1368)

Before:
<img width="1797" height="946" alt="Screenshot 2025-08-18 at 15 17 51" src="https://github.com/user-attachments/assets/db579e10-0398-4797-ae58-ca848a5dbc9e" />

After:
<img width="1800" height="944" alt="Screenshot 2025-08-18 at 15 17 35" src="https://github.com/user-attachments/assets/a424a3b1-f1d9-476b-a9f1-6b4944dda4fb" />

