### PR TITLE
Add doccard styling for inside tables

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -224,6 +224,17 @@ html[data-theme="dark"] {
   max-width: 100%!important;
 }
 
+table .card{
+  min-width: 250px;
+  max-width: 400px;
+}
+
+@media (max-width: 768px) {
+  table .card{
+    min-width: 182px;
+  }
+}
+
 /* Pagination Link styling */
 .pagination-nav__link {
   border: none !important;


### PR DESCRIPTION
Fix styling to show content of all doccards inside of tables.

Before:
<img width="1028" height="629" alt="Screenshot 2025-08-28 at 13 34 11" src="https://github.com/user-attachments/assets/15e53c4c-69fd-41c4-bc67-9ddab119204f" />

After:
<img width="1039" height="611" alt="Screenshot 2025-08-28 at 13 33 48" src="https://github.com/user-attachments/assets/81f25ebc-4a5c-4ce8-a96b-e9465cf33780" />

