### PR TITLE
docs/node/run-your-node: Document use of client-stateless mode

### DIFF
--- a/docs/node/grpc.mdx
+++ b/docs/node/grpc.mdx
@@ -117,17 +117,28 @@ static_resources:
   Consensus/(\
     EstimateGas|\
     GetBlock|\
+    GetBlockResults|\
     GetChainContext|\
     GetGenesisDocument|\
+    GetLastRetainedHeight|\
+    GetLatestHeight|\
+    GetLightBlock|\
     GetNextBlockState|\
     GetParameters|\
     GetSignerNonce|\
     GetStatus|\
     GetTransactions|\
     GetTransactionsWithResults|\
+    GetTransactionsWithProofs|\
     GetUnconfirmedTransactions|\
     MinGasPrice|\
-    SubmitTx)|\
+    SubmitEvidence|\
+    SubmitTx|\
+    SubmitTxWithProof|\
+    StateSyncGet|\
+    StateSyncGetPrefixes|\
+    StateSyncIterate|\
+    WatchBlocks)|\
   Governance/(\
     ActiveProposals|\
     ConsensusParameters|\
@@ -157,6 +168,7 @@ static_resources:
   RuntimeClient/(\
     CheckTx|\
     GetBlock|\
+    GetBlockResults|\
     GetEvents|\
     GetGenesisBlock|\
     GetLastRetainedBlock|\

--- a/docs/node/run-your-node/README.mdx
+++ b/docs/node/run-your-node/README.mdx
@@ -84,9 +84,14 @@ one or more [ROFL apps].
 ParaTimes such as Sapphire and Cipher that supports confidential smart contact
 queries.
 
+- **[Stateless Node]** is a special type of client node that operates without
+maintaining state, allowing it to bootstrap instantly, making it particularly
+well-suited for ROFL development.
+
 [Non-Validator Node]: ./non-validator-node.mdx
 [Client Node]: ./paratime-client-node.mdx
 [Observer Node]: ./paratime-observer-node.mdx
+[Stateless Node]: ./paratime-client-node.mdx#stateless-client-node-optional
 [Sapphire Client Node]: ./paratime-client-node.mdx
 [Cipher Client Node]: ./paratime-client-node.mdx
 [ROFL Node]: ./rofl-node.mdx

--- a/docs/node/run-your-node/paratime-client-node.mdx
+++ b/docs/node/run-your-node/paratime-client-node.mdx
@@ -76,23 +76,33 @@ accessible on the internet (for `TCP` and `UDP` traffic).
 [Mainnet]: ../network/mainnet.md
 [Testnet]: ../network/testnet.md
 
-### Steteless Client Node (optional)
+### Stateless Client Node (optional)
 
-Client node requires sufficient disk space and must wait for synchronization.
-A stateless client node fetches state via configured gRPC endpoints (provider node addresses) and uses a light client
-to verify data against state roots from block headers. It can be started using the following configuration:
+Client node requires sufficient disk space and must wait for state synchronization.
+A stateless client node avoids these problems by fetching the state and light blocks via configured gRPC endpoints
+(provider node addresses) and using a light client to verify the data against state roots from block headers.
+It can be started using the following configuration:
 
 ```yaml
 mode: client-stateless
 # ... sections not relevant are omitted ...
 consensus:
+    # Light client configuration
+    light_client:
+        trust:
+            # ... sections less relevant are omitted ...
     providers:
         - <node-address-1>
         - <node-address-2>
         # Add more node addresses as needed
 ```
 
-To ensure compatibility, all provider nodes specified must be running the latest version of Oasis Core.
+See the [State Sync](./advanced/sync-node-using-state-sync.md) documentation for configuring trusted period, height and
+hash for the light client.
+
+To ensure compatibility, all provider nodes specified must be running the latest version of Oasis Core. The provider
+address contains the `oasis1` prefix. It can also be an IP of a node on the network, or a path to the socket of a local
+node.
 
 ### TEE ParaTime Client Node (optional)
 

--- a/docs/node/run-your-node/paratime-client-node.mdx
+++ b/docs/node/run-your-node/paratime-client-node.mdx
@@ -78,6 +78,12 @@ accessible on the internet (for `TCP` and `UDP` traffic).
 
 ### Stateless Client Node (optional)
 
+:::info
+
+Stateless client is still in early stage, and thus not suitable for use cases where you need high availability.
+
+:::
+
 Client node requires sufficient disk space and must wait for state synchronization.
 A stateless client node avoids these problems by fetching the state and light blocks via configured gRPC endpoints
 (provider node addresses) and using a light client to verify the data against state roots from block headers.
@@ -97,12 +103,30 @@ consensus:
         # Add more node addresses as needed
 ```
 
-See the [State Sync](./advanced/sync-node-using-state-sync.md) documentation for configuring trusted period, height and
-hash for the light client.
+We recommend configuring a recent trust root (e.g. 1000 blocks old), that is younger than your providers last retained
+height, taking their pruning into account.
 
-To ensure compatibility, all provider nodes specified must be running the latest version of Oasis Core. The provider
-address contains the `oasis1` prefix. It can also be an IP of a node on the network, or a path to the socket of a local
-node.
+:::info
+
+See the [State Sync](./advanced/sync-node-using-state-sync.md) documentation for more info on configuring trusted
+period, height and hash for the light client.
+
+:::
+
+The provider address can be a domain name, IP of a node on the network, or a path to the socket of a local node.
+To ensure compatibility, all provider nodes specified must be running the latest version of Oasis Core.
+
+:::note
+
+Make sure you allow all the methods listed in [this example](../grpc.mdx#envoy) in your gRPC proxy for Oasis node.
+
+:::
+
+:::tip
+
+You can use `grpc.oasis.io:443` or `grpc.testnet.oasis.io:443` as provider addresses for Mainnet and Testnet.
+
+:::
 
 ### TEE ParaTime Client Node (optional)
 

--- a/docs/node/run-your-node/paratime-client-node.mdx
+++ b/docs/node/run-your-node/paratime-client-node.mdx
@@ -76,6 +76,24 @@ accessible on the internet (for `TCP` and `UDP` traffic).
 [Mainnet]: ../network/mainnet.md
 [Testnet]: ../network/testnet.md
 
+### Steteless Client Node (optional)
+
+Client node requires sufficient disk space and must wait for synchronization.
+A stateless client node fetches state via configured gRPC endpoints (provider node addresses) and uses a light client
+to verify data against state roots from block headers. It can be started using the following configuration:
+
+```yaml
+mode: client-stateless
+# ... sections not relevant are omitted ...
+consensus:
+    providers:
+        - <node-address-1>
+        - <node-address-2>
+        # Add more node addresses as needed
+```
+
+To ensure compatibility, all provider nodes specified must be running the latest version of Oasis Core.
+
 ### TEE ParaTime Client Node (optional)
 
 If your node requires the ability to issue queries that can access confidential

--- a/docs/node/run-your-node/rofl-node.mdx
+++ b/docs/node/run-your-node/rofl-node.mdx
@@ -34,7 +34,7 @@ Node instructions:
 [Testnet]: ../network/testnet.md#sapphire
 [Intel TDX]: ./prerequisites/set-up-tee.mdx#tdx
 [rofl-types]: https://github.com/oasisprotocol/oasis-sdk/blob/main/docs/rofl/workflow/init.md
-[client-stateless]: ./paratime-client-node.mdx#steteless-client-node-optional
+[client-stateless]: ./paratime-client-node.mdx#stateless-client-node-optional
 
 :::tip
 

--- a/docs/node/run-your-node/rofl-node.mdx
+++ b/docs/node/run-your-node/rofl-node.mdx
@@ -34,6 +34,13 @@ Node instructions:
 [Testnet]: ../network/testnet.md#sapphire
 [Intel TDX]: ./prerequisites/set-up-tee.mdx#tdx
 [rofl-types]: https://github.com/oasisprotocol/oasis-sdk/blob/main/docs/rofl/workflow/init.md
+[client-stateless]: ./paratime-client-node.mdx#steteless-client-node-optional
+
+:::tip
+
+Consider running ROFL node in [client-stateless] mode for faster bootstrapping and using less resources.
+
+:::
 
 ### Configure Firewall
 


### PR DESCRIPTION
Oasis Core [25.5](https://github.com/oasisprotocol/oasis-core/releases/tag/v25.5) has brought support for stateless client nodes, which are particularly suitable for ROFL nodes. 
We are documenting that here.