### PR TITLE
Exclude "See also" sections from search

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -100,6 +100,7 @@ const config: Config = {
       {
         indexBlog: false,
         docsRouteBasePath: '/',
+        ignoreCssSelectors: '.exclude-from-search',
       } satisfies import('@easyops-cn/docusaurus-search-local').PluginOptions,
     ],
   ],

--- a/src/theme/DocCard/index.tsx
+++ b/src/theme/DocCard/index.tsx
@@ -38,14 +38,16 @@ function useCategoryItemsPlural() {
 function CardContainer({
   href,
   children,
+  className,
 }: {
   href: string;
   children: ReactNode;
+  className?: string;
 }): ReactNode {
   return (
     <Link
       href={href}
-      className={clsx('card padding--lg', styles.cardContainer)}>
+      className={clsx('card padding--lg', styles.cardContainer, className)}>
       {children}
     </Link>
   );
@@ -57,15 +59,17 @@ function CardLayout({
   title,
   description,
   customProps,
+  className,
 }: {
   href: string;
   icon: ReactNode;
   title: string;
   description?: string;
   customProps: {[key: string]: unknown} | undefined;
+  className?: string;
 }): ReactNode {
   return (
-    <CardContainer href={href}>
+    <CardContainer href={href} className={className}>
       <Heading
         as="h3"
         className={clsx('text--truncate', styles.cardTitle)}
@@ -92,7 +96,7 @@ function CardLayout({
   );
 }
 
-function CardCategory({item}: {item: PropSidebarItemCategory}): ReactNode {
+function CardCategory({item, className}: {item: PropSidebarItemCategory, className?: string}): ReactNode {
   const href = findFirstSidebarItemLink(item);
   const categoryItemsPlural = useCategoryItemsPlural();
 
@@ -109,11 +113,12 @@ function CardCategory({item}: {item: PropSidebarItemCategory}): ReactNode {
       // description={item.description ?? categoryItemsPlural(item.items.length)}
       description={item.description}
       customProps={item.customProps}
+      className={className}
     />
   );
 }
 
-function CardLink({item}: {item: PropSidebarItemLink}): ReactNode {
+function CardLink({item, className}: {item: PropSidebarItemLink, className?: string}): ReactNode {
   const icon = isInternalUrl(item.href) ? '📄️' : '🔗';
   const doc = useDocById(item.docId ?? undefined);
   return (
@@ -123,6 +128,7 @@ function CardLink({item}: {item: PropSidebarItemLink}): ReactNode {
       title={item.label}
       description={item.description ?? doc?.description}
       customProps={item.customProps}
+      className={className}
     />
   );
 }
@@ -130,9 +136,9 @@ function CardLink({item}: {item: PropSidebarItemLink}): ReactNode {
 export default function DocCard({item}: Props): ReactNode {
   switch (item.type) {
     case 'link':
-      return <CardLink item={item} />;
+      return <CardLink item={item} className="exclude-from-search" />;
     case 'category':
-      return <CardCategory item={item} />;
+      return <CardCategory item={item} className="exclude-from-search" />;
     default:
       throw new Error(`unknown item type ${JSON.stringify(item)}`);
   }


### PR DESCRIPTION
Fixes https://github.com/oasisprotocol/docs/issues/1284

https://docs.oasis.io/search/?q=rofl
| Before | After |
| --- | --- |
| <img width="692" height="785" alt="Screenshot from 2025-11-17 20-09-51" src="https://github.com/user-attachments/assets/a223b99b-e2ef-4da8-a8c9-3ff371801292" />       |       <img width="692" height="785" alt="Screenshot from 2025-11-17 19-56-26" src="https://github.com/user-attachments/assets/c2ee65b3-e492-45ff-b7b4-9b9e19776657" /> |

(e.g. second result came from
<img width="692" height="785" alt="Screenshot from 2025-11-17 20-14-37" src="https://github.com/user-attachments/assets/ad4473a2-828e-4ad7-9d09-0da9a90c2326" />
)

