### PR TITLE
build/trustless-agent: Update sha256 hash of the rofl-8004 image

### DIFF
--- a/docs/build/use-cases/trustless-agent.mdx
+++ b/docs/build/use-cases/trustless-agent.mdx
@@ -80,7 +80,7 @@ services:
       - eliza-storage:/root/.eliza
 
   rofl-8004:
-    image: ghcr.io/oasisprotocol/rofl-8004@sha256:2226a17a56420c271362ca7874d243efb63ddafb608b661f488c10e54bc24f63
+    image: ghcr.io/oasisprotocol/rofl-8004@sha256:f57373103814a0ca4c0a03608284451221b026e695b0b8ce9ca3d4153819a349
     platform: linux/amd64
     environment:
       - RPC_URL=${RPC_URL}


### PR DESCRIPTION
Bumps the rofl-8004 image.