### PR TITLE
use-cases/trustless-agent: Increase storage from 5 GB to 10 GB

### DIFF
--- a/docs/build/use-cases/trustless-agent.mdx
+++ b/docs/build/use-cases/trustless-agent.mdx
@@ -119,7 +119,7 @@ Inspect on-chain activity and app details in the [Oasis Explorer].
 
 ## Build ROFL bundle
 
-Eliza requires at least 2 GiB of memory and 5 GB of storage. Update the
+Eliza requires at least 2 GiB of memory and 10 GB of storage. Update the
 `resources` section in `rofl.yaml` accordingly:
 
 ```yaml title="rofl.yaml"
@@ -128,7 +128,7 @@ resources:
   cpus: 1
   storage:
     kind: disk-persistent
-    size: 5000
+    size: 10000
 ```
 
 Then, build the ROFL bundle by invoking:


### PR DESCRIPTION
It turns out 5GB is not enough to download all images in compose + the system ones. 10 GB works fine.