### PR TITLE
use-cases/key-generation: Shorten title

### DIFF
--- a/docs/build/use-cases/key-generation.mdx
+++ b/docs/build/use-cases/key-generation.mdx
@@ -7,7 +7,7 @@ tags: [ROFL, appd, KMS, EVM]
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-# Cross-Chain Key Generation on ROFL (EVM / Base)
+# Cross-Chain Key Generation (EVM / Base)
 
 This chapter shows how to build a tiny TypeScript app that **generates a
 secp256k1 key inside ROFL** using the


### PR DESCRIPTION
Since ROFL is already a tag and mentioned in the first paragraph it makes sense to trim "on ROFL" in "Cross-Chain Key Generation on ROFL (EVM / Base)" so that it fits one line.