### PR TITLE
Update testnet.md

### DIFF
--- a/docs/node/network/testnet.md
+++ b/docs/node/network/testnet.md
@@ -43,7 +43,7 @@ Feel free to use other seed nodes besides the one provided here.
 :::
 
 * [Oasis Core](https://github.com/oasisprotocol/oasis-core) version:
-  * [25.8](https://github.com/oasisprotocol/oasis-core/releases/tag/v25.8)
+  * [25.9](https://github.com/oasisprotocol/oasis-core/releases/tag/v25.9)
 * [Oasis Rosetta Gateway](https://github.com/oasisprotocol/oasis-rosetta-gateway) version:
   * [2.7.0](https://github.com/oasisprotocol/oasis-rosetta-gateway/releases/tag/v2.7.0)
 
@@ -62,7 +62,7 @@ This chapter contains parameters for various ParaTimes known to be deployed on t
 ### Sapphire
 
 * Oasis Core version:
-  * [25.8](https://github.com/oasisprotocol/oasis-core/releases/tag/v25.8)
+  * [25.9](https://github.com/oasisprotocol/oasis-core/releases/tag/v25.9)
 * Runtime identifier:
   * `000000000000000000000000000000000000000000000000a6d1e3ebf60dff6c`
 * Runtime bundle version:
@@ -73,7 +73,7 @@ This chapter contains parameters for various ParaTimes known to be deployed on t
 ### Cipher
 
 * Oasis Core version:
-  * [25.8](https://github.com/oasisprotocol/oasis-core/releases/tag/v25.8)
+  * [25.9](https://github.com/oasisprotocol/oasis-core/releases/tag/v25.9)
 * Runtime identifier:
   * `0000000000000000000000000000000000000000000000000000000000000000`
 * Runtime bundle version:
@@ -82,7 +82,7 @@ This chapter contains parameters for various ParaTimes known to be deployed on t
 ### Emerald
 
 * Oasis Core version:
-  * [25.8](https://github.com/oasisprotocol/oasis-core/releases/tag/v25.8)
+  * [25.9](https://github.com/oasisprotocol/oasis-core/releases/tag/v25.9)
 * Runtime identifier:
   * `00000000000000000000000000000000000000000000000072c8215e60d5bca7`
 * Runtime bundle version (or [build your own](https://github.com/oasisprotocol/emerald-paratime/tree/v11.0.0-testnet#building)):
@@ -93,7 +93,7 @@ This chapter contains parameters for various ParaTimes known to be deployed on t
 ### Key Manager
 
 * Oasis Core version:
-  * [25.8](https://github.com/oasisprotocol/oasis-core/releases/tag/v25.8)
+  * [25.9](https://github.com/oasisprotocol/oasis-core/releases/tag/v25.9)
 * Runtime identifier:
   * `4000000000000000000000000000000000000000000000004a1a53dff2ae482d`
 * Runtime bundle version:


### PR DESCRIPTION
Oasis Core 25.9 for TESTNET was released.
Docs should be aligned.