### PR TITLE
Add all use cases to the landing page

### DIFF
--- a/docs/README.mdx
+++ b/docs/README.mdx
@@ -19,6 +19,8 @@ import BlocksSvg from "@site/static/img/BlocksGraphic.svg?react";
     itemPaths={[
         "/build/use-cases/key-generation",
         "/build/use-cases/trustless-agent",
+        "/build/use-cases/price-oracle",
+        "/build/use-cases/tgbot",
     ]}
     svg={<OasisSvg className="animatedSvg" />}
 >

--- a/docs/build/use-cases/price-oracle.mdx
+++ b/docs/build/use-cases/price-oracle.mdx
@@ -322,9 +322,20 @@ Last update at:   656
 That's it! Your first ROFL oracle that authenticates with an Oasis Sapphire
 smart contract is running! 🎉
 
-:::example Price Oracle Demo
+:::example ROFL Price Oracle
 
 You can fetch a complete example shown in this chapter from
 https://github.com/oasisprotocol/demo-rofl.
+
+Next, you can check out the [production version of the price
+oracle][rofl-price-oracle] maintained by the Oasis team. This oracle is
+deployed on [Mainnet] and [Testnet], supports fetching price quotes from
+various CEXes in parallel, the API keys to avoid quota limits and stores the
+quotes to a ChainLink-compatible smart contract on Sapphire ready to be
+consumed by DeFi apps.
+
+[Mainnet]: https://explorer.oasis.io/mainnet/sapphire/rofl/app/rofl1qph068ccezgmw25qtrv47z8ecv898wzk2g8ys99w
+[Testnet]: https://explorer.oasis.io/testnet/sapphire/rofl/app/rofl1qzcaz2y24anz6qy4w8jhuc5vj9cwhek8ustkl8a7
+[rofl-price-oracle]: https://github.com/oasisprotocol/rofl-price-oracle
 
 :::

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -256,7 +256,7 @@ Apache 2.0</a>. Built with &#x2665; and Docusaurus.</p>`,
       prism: {
         theme: prismThemes.github,
         darkTheme: prismThemes.dracula,
-        additionalLanguages: ['diff', 'rust', 'solidity', 'toml', 'ini'],
+        additionalLanguages: ['diff', 'rust', 'solidity', 'toml', 'ini', 'bash', 'docker'],
       },
       colorMode: {
         respectPrefersColorScheme: true,

--- a/src/components/DocCardSection.module.css
+++ b/src/components/DocCardSection.module.css
@@ -115,6 +115,10 @@
   display: none !important;
 }
 
+.cardItem a div { /* Pill */
+  margin-top: 5px;
+}
+
 .cardLinksList .cardItem:last-child {
   border-bottom: none;
 }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -350,7 +350,3 @@ a[rel="tag"] {
 .theme-admonition-example svg{
   fill: transparent!important;
 }
-
-.theme-admonition-example p{
-  margin-bottom: 0;
-}


### PR DESCRIPTION
Resolves #1603 

This PR:
- adds all 4 use cases to the landing page
- enables bash and dockerfile syntax highlighting too
- fixes paragraph margins in admonitions
- fixes top margin of the tags on the landing page