### PR TITLE
docs/node/grpc: Remove GetSignerNonce from Envoy

### DIFF
--- a/docs/node/grpc.mdx
+++ b/docs/node/grpc.mdx
@@ -125,7 +125,6 @@ static_resources:
     GetLightBlock|\
     GetNextBlockState|\
     GetParameters|\
-    GetSignerNonce|\
     GetStatus|\
     GetTransactions|\
     GetTransactionsWithResults|\


### PR DESCRIPTION
Release 26.0 should not have this method anymore. For details, see:
 - https://github.com/oasisprotocol/oasis-core/pull/6208