### PR TITLE
docs: add docusaurus-plugin-copy-page-button

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -95,6 +95,7 @@ const config: Config = {
       };
     },
     llmsPlugin,
+    'docusaurus-plugin-copy-page-button',
     [
       '@docusaurus/plugin-client-redirects',
       redirectsOptions,

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@mdx-js/react": "^3.0.0",
     "@mermaid-js/mermaid-cli": "^11.4.0",
     "clsx": "^2.0.0",
+    "docusaurus-plugin-copy-page-button": "^0.6.1",
     "fathom-client": "^3.7.2",
     "linkinator": "^6.0.3",
     "markdownlint-cli2": "^0.11.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12765,6 +12765,11 @@ zod@^4.1.8:
   resolved "https://registry.yarnpkg.com/zod/-/zod-4.1.12.tgz#64f1ea53d00eab91853195653b5af9eee68970f0"
   integrity sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ==
 
+docusaurus-plugin-copy-page-button@^0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/docusaurus-plugin-copy-page-button/-/docusaurus-plugin-copy-page-button-0.6.1.tgz#901bc9fed88eb8afda5838c634e81a69d312db54"
+  integrity sha512-84LUG23owdGlUx5rgg7lcyuuxFZ+84u9u+adYjFZ1E5lM+g6bkduOGcZXLUqbI0R2Ve2RjG0OPv2KaL01tGW4w==
+
 zwitch@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/zwitch/-/zwitch-2.0.4.tgz#c827d4b0acb76fc3e685a4c6ec2902d51070e9d7"


### PR DESCRIPTION
## Summary
- add `docusaurus-plugin-copy-page-button` to the docs dependencies
- register the plugin in `docusaurus.config.ts`

## Why
Oasis docs include protocol, SDK, and developer reference pages that are useful to bring into AI tools. This adds a page-level copy/open button that exports the current page as clean markdown and includes one-click Open in ChatGPT, Claude, and Gemini actions.

I checked the repo for overlapping features before opening this. Oasis already has `llms.txt`, `llms-full.txt`, and Context7 MCP documentation for corpus-level AI ingestion. This PR is different: it adds a page-level UI action for copying or opening the current page directly from the docs page.

The plugin has no runtime dependencies and uses peer dependencies for Docusaurus and React.

## Validation
- `git diff --check`
- package manifest, lockfile, and config sanity check

Not run locally: full docs build, due the dependency install/build footprint in this environment.