### PR TITLE
docs/node/network/testnet: Bump Core to 26.1

### DIFF
--- a/docs/node/network/testnet.md
+++ b/docs/node/network/testnet.md
@@ -43,7 +43,7 @@ Feel free to use other seed nodes besides the one provided here.
 :::
 
 * [Oasis Core](https://github.com/oasisprotocol/oasis-core) version:
-  * [26.0](https://github.com/oasisprotocol/oasis-core/releases/tag/v26.1)
+  * [26.1](https://github.com/oasisprotocol/oasis-core/releases/tag/v26.1)
 * [Oasis Rosetta Gateway](https://github.com/oasisprotocol/oasis-rosetta-gateway) version:
   * [2.8.0](https://github.com/oasisprotocol/oasis-rosetta-gateway/releases/tag/v2.8.0)
 
@@ -62,7 +62,7 @@ This chapter contains parameters for various ParaTimes known to be deployed on t
 ### Sapphire
 
 * Oasis Core version:
-  * [26.0](https://github.com/oasisprotocol/oasis-core/releases/tag/v26.1)
+  * [26.1](https://github.com/oasisprotocol/oasis-core/releases/tag/v26.1)
 * Runtime identifier:
   * `000000000000000000000000000000000000000000000000a6d1e3ebf60dff6c`
 * Runtime bundle version:
@@ -73,7 +73,7 @@ This chapter contains parameters for various ParaTimes known to be deployed on t
 ### Cipher
 
 * Oasis Core version:
-  * [26.0](https://github.com/oasisprotocol/oasis-core/releases/tag/v26.1)
+  * [26.1](https://github.com/oasisprotocol/oasis-core/releases/tag/v26.1)
 * Runtime identifier:
   * `0000000000000000000000000000000000000000000000000000000000000000`
 * Runtime bundle version:
@@ -82,7 +82,7 @@ This chapter contains parameters for various ParaTimes known to be deployed on t
 ### Emerald
 
 * Oasis Core version:
-  * [26.0](https://github.com/oasisprotocol/oasis-core/releases/tag/v26.1)
+  * [26.1](https://github.com/oasisprotocol/oasis-core/releases/tag/v26.1)
 * Runtime identifier:
   * `00000000000000000000000000000000000000000000000072c8215e60d5bca7`
 * Runtime bundle version (or [build your own](https://github.com/oasisprotocol/emerald-paratime/tree/v11.0.0-testnet#building)):
@@ -93,7 +93,7 @@ This chapter contains parameters for various ParaTimes known to be deployed on t
 ### Key Manager
 
 * Oasis Core version:
-  * [26.0](https://github.com/oasisprotocol/oasis-core/releases/tag/v26.1)
+  * [26.1](https://github.com/oasisprotocol/oasis-core/releases/tag/v26.1)
 * Runtime identifier:
   * `4000000000000000000000000000000000000000000000004a1a53dff2ae482d`
 * Runtime bundle version:


### PR DESCRIPTION
Forgot to change the name of the links.