### PR TITLE
run-your-node: Add instructions for Ubuntu 26.x to TEE prerequisites

### DIFF
--- a/docs/node/run-your-node/paratime-observer-node.mdx
+++ b/docs/node/run-your-node/paratime-observer-node.mdx
@@ -105,7 +105,7 @@ prevent replay attacks.
    registration is necessary.
 
    ```yaml
-   mode: client
+   mode: observer
    # ... sections not relevant are omitted ...
    registration:
      entity_id: {{ entity_id }}

--- a/docs/node/run-your-node/prerequisites/set-up-tee.mdx
+++ b/docs/node/run-your-node/prerequisites/set-up-tee.mdx
@@ -15,7 +15,7 @@ To run SGX/TDX enclaves:
 1. your hardware must have SGX/TDX support,
 2. you must have the latest BIOS updates installed,
 3. you must have SGX/TDX enabled in your BIOS,
-4. you must have the Linux kernel, drivers and software components properly
+4. you must have the Linux kernel, drivers, and software components properly
    installed and running.
 
 [Intel SGX]: https://www.intel.com/content/www/us/en/architecture-and-technology/software-guard-extensions.html
@@ -94,19 +94,20 @@ and look for the following line:
 
 ### DCAP Attestation
 
-#### Ubuntu 22.04+
+#### Ubuntu 24.04+
 
-A convenient way to install the AESM service on Ubuntu 22.04 systems
-is to use the Intel's [official Intel SGX APT repository](https://download.01.org/intel-sgx/sgx_repo/).
+A convenient way to install the AESM service on Ubuntu 24.04 and newer systems
+is to use the Intel's [official Intel SGX APT repository].
 
-First add Intel SGX APT repository to your system:
+First, add the Intel SGX APT repository to your system:
 
 ```bash
 curl -fsSL https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | sudo gpg --dearmor -o /usr/share/keyrings/intel-sgx-deb.gpg
 echo "deb [arch=amd64 signed-by=/usr/share/keyrings/intel-sgx-deb.gpg] https://download.01.org/intel-sgx/sgx_repo/ubuntu $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/intel-sgx.list > /dev/null
 ```
 
-And then install the `sgx-aesm-service`, `libsgx-aesm-ecdsa-plugin`, `libsgx-aesm-quote-ex-plugin` and `libsgx-dcap-default-qpl` packages:
+Then install the `sgx-aesm-service`, `libsgx-aesm-ecdsa-plugin`,
+`libsgx-aesm-quote-ex-plugin` and `libsgx-dcap-default-qpl` packages:
 
 ```bash
 sudo apt update
@@ -118,6 +119,8 @@ The AESM service should be up and running. To confirm that, use:
 ```bash
 sudo systemctl status aesmd.service
 ```
+
+[official Intel SGX APT repository]: https://download.01.org/intel-sgx/sgx_repo/
 
 #### Configuring the Quote Provider
 
@@ -194,7 +197,7 @@ Alternatively, an easy way to install and run the AESM service on a [Docker](htt
 system is to use [our AESM container image](https://github.com/oasisprotocol/oasis-core/pkgs/container/aesmd).
 
 Executing the following command should (always) pull the latest version of our
-AESMD Docker container, map the SGX devices and `/var/run/aesmd` directory
+AESMD Docker container, map the SGX devices and `/var/run/aesmd` directory,
 and ensure AESM is running in the background (also automatically started on boot):
 
 ```bash
@@ -240,7 +243,7 @@ provisioning process uses UEFI variables to communicate with the BIOS. In
 addition the **SGX Auto MP Registration** BIOS configuration setting should be
 set to _enabled_.
 
-##### Ubuntu 22.04+
+##### Ubuntu 24.04+
 
 To provision and register your multi-socket system you need to install the Intel
 SGX Multi-Package Registration Agent Service as follows (assuming Intel's SGX
@@ -300,67 +303,31 @@ installation steps above and you have a working SGX environment**!
 ### Host OS setup
 
 The following section contains summarized instructions for setting up an
-environment for running ROFL node and other TDX services on Ubuntu 24.04 or
-later. Check out the official [Canonical TDX repository] for details.
+environment for running ROFL node and other TDX services on Ubuntu 26.04 or
+newer. Check out the official [Canonical TDX howto] for details.
 
-[Canonical TDX repository]: https://github.com/canonical/tdx
-
-1. Add the following TDX PPAs to your APT sources and the keyring:
-
-   ```shell
-   sudo add-apt-repository ppa:kobuk-team/tdx-release
-   sudo add-apt-repository ppa:kobuk-team/tdx-attestation-release
-   sudo apt update
-   ```
-2. Install the TDX quote generation service and QEMU for running
-   guest virtual machines:
+1. Install the TDX quote generation service from the Intel's SGX APT
+   repository and QEMU for running guest virtual machines:
 
     ```shell
     sudo apt install tdx-qgs qemu-utils qemu-system-x86
     ```
 
-3. Install a special TDX-enabled Linux kernel:
-
-    ```shell
-    sudo apt install linux-image-intel
-    ```
-
-3. Disable ACPI S3 (add kernel parameter: `nohibernate`):
+2. Disable ACPI S3 and enable TDX (add kernel parameters:
+   `nohibernate kvm_intel.tdx=1`):
 
    ```
-   sed -i -E "s/GRUB_CMDLINE_LINUX=\"(.*)\"/GRUB_CMDLINE_LINUX=\"\1 nohibernate\"/g" /etc/default/grub
+   sed -i -E "s/GRUB_CMDLINE_LINUX=\"(.*)\"/GRUB_CMDLINE_LINUX=\"\1nohibernate kvm_intel.tdx=1\"/g" /etc/default/grub
    update-grub
    ```
 
-4. Make sure the non-root user running Oasis-node is a member of `sgx`,
+3. Make sure the non-root user running Oasis-node is a member of `sgx`,
    `sgx_prv` and `kvm` groups on host (access to `/dev/sgx*`, `/dev/kvm*` and
    `/dev/*vsock*` devices).
 
-5. Reboot your system and select the new `-intel` kernel.
+4. Reboot your system.
 
-:::tip
-
-If you don't have access to the grub selector during machine startup, you can
-also detect and set the correct default kernel by executing the script below
-with elevated privileges:
-
-```bash
-export KERNEL_RELEASE=$(apt show "linux-image-intel" 2>&1 | gawk 'match($0, /Depends:.* linux-image-([^, ]+)/, a) {print a[1]}')
-if [ -z "${KERNEL_RELEASE}" ]; then
-    echo "ERROR : unable to determine kernel release"
-    exit 1
-fi
-MID=$(awk '/Advanced options for Ubuntu/{print $(NF-1)}' /boot/grub/grub.cfg | cut -d\' -f2)
-KID=$(awk "/with Linux $KERNEL_RELEASE/"'{print $(NF-1)}' /boot/grub/grub.cfg | cut -d\' -f2 | head -n1)
-cat > /etc/default/grub.d/99-tdx-kernel.cfg <<EOF
-GRUB_DEFAULT=saved
-GRUB_SAVEDEFAULT=true
-EOF
-grub-editenv /boot/grub/grubenv set saved_entry="${MID}>${KID}"
-update-grub
-```
-
-:::
+[Canonical TDX howto]: https://ubuntu.com/server/docs/how-to/virtualisation/intel-tdx/
 
 ### Check TDX Setup
 

--- a/docs/node/run-your-node/prerequisites/system-configuration.mdx
+++ b/docs/node/run-your-node/prerequisites/system-configuration.mdx
@@ -157,7 +157,7 @@ creation, you may need to allow them for Bubblewrap (the sandbox that Oasis Node
 using to execute runtimes).
 
 <Tabs>
-<TabItem value="Ubuntu 24.04 and earlier">
+<TabItem value="Ubuntu 24.04">
 
     You can add the following policy in `/etc/apparmor.d/bwrap`:
 


### PR DESCRIPTION
This PR:
- simplifies TDX installation only covering Ubuntu 26.04 which brings TDX support in the default kernel.
- fixes `mode: client` -> `mode: observer` in ROFL node config.
- Bumps bubblewrap instructions from 22.04 to 24.04 because oasis-node doesn't run anymore on Ubuntu 22.04.