### PR TITLE
docs: Add missing leading space before kernel params

### DIFF
--- a/docs/node/run-your-node/prerequisites/set-up-tee.mdx
+++ b/docs/node/run-your-node/prerequisites/set-up-tee.mdx
@@ -317,7 +317,7 @@ newer. Check out the official [Canonical TDX howto] for details.
    `nohibernate kvm_intel.tdx=1`):
 
    ```
-   sed -i -E "s/GRUB_CMDLINE_LINUX=\"(.*)\"/GRUB_CMDLINE_LINUX=\"\1nohibernate kvm_intel.tdx=1\"/g" /etc/default/grub
+   sed -i -E "s/GRUB_CMDLINE_LINUX=\"(.*)\"/GRUB_CMDLINE_LINUX=\"\1 nohibernate kvm_intel.tdx=1\"/g" /etc/default/grub
    update-grub
    ```
 


### PR DESCRIPTION
Followup to #1763 

The current solution only worked for empty initial kernel parameters.