### PR TITLE
docs: add OpenChainBench live RPC latency benchmark link

### DIFF
--- a/docs/build/tools/other-paratimes/emerald/network.mdx
+++ b/docs/build/tools/other-paratimes/emerald/network.mdx
@@ -54,6 +54,17 @@ dedicated RPC endpoints, consider the following providers (in alphabetic order):
 [1RPC-docs]: https://docs.1rpc.io/guide/how-to-use-1rpc
 [1RPC-pricing]: https://www.1rpc.io/#pricing
 
+## RPC Benchmarks
+
+[OpenChainBench] provides independent, continuous latency measurements for public Emerald RPC endpoints (p50/p90/p99, updated every 60 s).
+
+| Benchmark | Notes |
+|-----------|-------|
+| [Oasis Emerald RPC benchmark][OCB-emerald] | Live p50/p90/p99 latency, Oasis Foundation leads at 247 ms p50 |
+
+[OpenChainBench]: https://openchainbench.com
+[OCB-emerald]: https://openchainbench.com/benchmarks/oasis-emerald-rpc
+
 ## Block Explorers
 
 | Name/Provider               | Mainnet URL                               | Testnet URL                               | EIP-3091 compatible |


### PR DESCRIPTION
## Summary

Adds a new **RPC Benchmarks** section to the Emerald network information page, linking to the independent OpenChainBench live latency benchmark for Oasis Emerald.

- Benchmark page: https://openchainbench.com/benchmarks/oasis-emerald-rpc
- Measurements: p50/p90/p99 latency, updated every 60 s
- Current leader: Oasis Foundation at 247 ms p50

The section follows the same structure as other entries in the page (table + reference links) and is placed before Block Explorers.

## Why

Developers choosing an RPC endpoint benefit from real latency data. OpenChainBench is an open, community-run benchmark with no affiliation to any single provider.